### PR TITLE
Phase 2: extraction (Firecrawl client + submit/status API + queue pickup)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 BASE_URL=https://audifeed.example.com
 UI_BASE_URL=https://audicle.example.com
 DATA_DIR=/data
-FIRECRAWL_URL=http://firecrawl:3002
+FIRECRAWL_URL=http://host.docker.internal:3002
 TTS_URL=http://tts-wrapper:8000
 LLM_PROVIDER=openai-compatible
 LLM_MODEL=qwen2.5:14b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Added (Phase 2 - Extraction)
+
+- Runtime deps: `httpx>=0.27`, `tenacity>=9.0`. `httpx` moved out of `[dependency-groups].dev` into runtime since the Firecrawl client and the reachability prober both use it.
+- `backend/app/services/extraction.py`: async Firecrawl client. POST `{FIRECRAWL_URL}/v1/scrape` with `{url, formats: ["markdown"]}`. Tenacity `AsyncRetrying` with `FIRECRAWL_RETRY_COUNT` attempts and exponential backoff seeded by `FIRECRAWL_BACKOFF_BASE_SECONDS`. Typed exceptions: `ExtractionError` (base), `ExtractionTransientError` (5xx / network / timeout, retryable), `ExtractionPermanentError` (4xx / malformed JSON / `success=false`), `ExtractionTooShortError` (below `MIN_EXTRACTION_CHARS`). Returns a frozen `ExtractionResult(markdown, metadata)`.
+- `backend/app/services/jobs.py`: pure DB helpers. `compute_episode_id(url)` = MD5 truncated to 12 hex; `get_job`, `get_job_by_episode_id`, `episode_exists`, `create_job` (with `DuplicateSubmissionError` and reprocess-wipes-prior semantics), `claim_next_queued` (atomic SELECT+UPDATE under `BEGIN IMMEDIATE`), `set_stage`, `mark_done`, `mark_failed`, `job_as_dict`. Every UPDATE bumps `updated_at` explicitly per the build plan's application-managed timestamps contract.
+- `backend/app/services/pipeline.py`: `process_job(job, settings)` orchestrator. Wraps the whole job under `asyncio.wait_for(JOB_TIMEOUT_SECONDS)`. Each stage writes its name to `jobs.stage` BEFORE running so the timeout path can report which stage was executing. Stage start/end/failure structured logs with `job_id` + `episode_id` + `stage` stamped via contextvars. Phase 2 wires only the `extract` stage; on success status=done with `stage=extract`. Phase 3+ will append cleanup and beyond.
+- `backend/app/services/reachability.py`: `check_firecrawl(settings)` and `run_all(settings)`. Probes `GET {FIRECRAWL_URL}/v1/health`. The worker calls `run_all` at startup and exits non-zero on failure so the container restart loop surfaces a misconfigured stack instead of every job failing the same way mid-pipeline. The FastAPI lifespan deliberately does NOT call `run_all` so `/health/ready` and the admin API stay reachable for triage even when Firecrawl is down.
+- `backend/app/worker.py`: polling loop now actually picks up queued jobs (`_pickup_once`), runs `pipeline.process_job`, and continues. Single in-flight. Reachability checks run before crash recovery and signal-handler install; failure causes `sys.exit(1)` so the supervisor cycles the container.
+- `backend/app/api/errors.py`: global error envelope. All 4xx and 5xx return `{error, status, details?}` per build plan. RequestValidationError → 400 with field details. Unhandled exceptions → 500 with logged traceback but no client-side leakage.
+- `backend/app/api/v1/` with `router.py`, `submit.py`, `status.py`. `POST /api/v1/submit` accepts `{url: AnyHttpUrl, reprocess?: bool}`, returns 201 `{job_id, episode_id, status, replaced_previous}`. 409 on duplicate (in-flight job OR existing episode without reprocess). 400 on invalid URL. `GET /api/v1/status/{job_id}` returns full job state or 404.
+- `backend/app/main.py`: mounts the v1 router and registers the error handlers alongside the existing health router.
+- `backend/app/config.py`: `JOB_TIMEOUT_SECONDS` widened from `int` to `float` so fractional values work in tests; production default unchanged at 1800.
+### Code-review pass (multi-agent /simplify + /code-review)
+
+Findings surfaced and applied:
+
+- **jobs.create_job race + non-atomic DELETE**: wrapped the entire duplicate-check + delete + insert in `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`. Two concurrent submits for the same URL can no longer both pass the in-flight check; a failure between the two DELETE statements in the reprocess path no longer leaves a half-wiped DB.
+- **claim_next_queued ROLLBACK secondary-error mask**: switched to `contextlib.suppress(OperationalError)` around the rollback, matching the pattern already used in `database._apply_pending`.
+- **extraction NoneType chain on `data: null`**: hardened `_parse_response` and the data/markdown/metadata extraction to handle `data=null`, non-dict bodies, and non-dict data with a typed `ExtractionPermanentError` instead of `AttributeError`.
+- **pipeline error finalization can secondary-raise**: extracted `_finalize_failure` that wraps `_last_stage` and `_persist_failure` in their own try/except; a locked DB during the error handler no longer masks the original stage exception and the structured `pipeline_failed` / `pipeline_timeout` log lines always fire.
+- **_run_stage missed CancelledError**: widened the except from `Exception` to `BaseException` so timeout-cancelled stages still emit the `stage_failed` log with duration_ms.
+- **worker poll loop unsafe**: wrapped `_process_one` in try/except so a transient DB or OS error logs and backs off instead of killing the worker process.
+- **SubmitRequest silently dropped unknown fields**: added `model_config = ConfigDict(extra="forbid")` so `{"reprcess": true}` (typo) surfaces as a 400 Validation failed instead of being silently ignored.
+- **AnyHttpUrl normalization changed user URL**: replaced the `AnyHttpUrl` field type with a `str` + `field_validator` that runs `AnyHttpUrl(value)` for validation but returns the raw string, keeping `episode_id` deterministic against the user-submitted URL and the persisted `url` byte-for-byte identical.
+- **_validation_handler unsafe JSON encoding**: wrapped `exc.errors()` in `jsonable_encoder` so non-primitive ctx values (Pattern, Enum, exception instances) don't fall through to the 500 handler.
+- **reachability hits non-existent /v1/health**: probe now tries `/v1/health`, `/health`, and `/` in order; first 2xx wins. Self-hosted Firecrawl versions that only respond at `/` no longer fail startup.
+- **extraction.\_raise_for_status magic numbers**: replaced bounds arithmetic with `response.is_server_error` / `response.is_client_error`.
+- **jobs.get_job_by_episode_id duplicated SELECTs**: collapsed to one query with an optional WHERE fragment.
+- **pipeline two except blocks duplicated**: shared via `_finalize_failure` helper.
+- **extraction trailing unreachable raise**: clarified the comment to acknowledge it's a type-checker satisfier.
+- **fast_backoff fixture was dead code**: replaced with a real fixture that sets `FIRECRAWL_BACKOFF_BASE_SECONDS=0` and clears the settings cache so retry tests actually run fast; deduped from each consumer.
+- **.env.example default `FIRECRAWL_URL=http://firecrawl:3002` resolved nowhere on a fresh clone**: changed default to `http://host.docker.internal:3002` matching the `OPENAI_BASE_URL` pattern.
+
+New tests added by the review pass (11 more, 59 total):
+
+- `test_reachability.py`: 6 tests covering check_firecrawl 2xx, fallback through endpoint candidates, network unreachable, persistent 5xx reports last detail, run_all raises on failure, run_all returns on success.
+- `test_api_v1.py`: 5 new tests — `extra="forbid"` rejects typo'd field, raw URL preserved through to status, reprocess+inflight still returns 409 with the right reason, status endpoint returns failed jobs with stage + error, 500 envelope contract (no detail leakage, never logs exc.args into response).
+
+- New tests (17 new, 59 total Phase 2 starting point pre-review):
+  - `test_extraction.py`: happy path, retries-then-succeeds on 5xx, no-retry on 4xx, retry exhaustion on persistent 5xx, MIN_EXTRACTION_CHARS guard, `success=false` rejection. Uses `httpx.MockTransport` via a factory monkeypatch on `httpx.AsyncClient`.
+  - `test_pipeline.py`: status=done with stage=extract on success; status=failed with stage+error on extraction error; status=failed with `JOB_TIMEOUT_SECONDS` error on timeout (last persisted stage reported).
+  - `test_api_v1.py`: submit 201 + 12-char episode_id; submit 400 on invalid URL via the validation handler; submit 409 on in-flight duplicate; submit reprocess=true wipes prior episode and returns `replaced_previous=true`; status 200 with full envelope; status 404 with envelope.
+  - `test_worker.py`: added `test_pickup_runs_pipeline_against_a_queued_job` (end-to-end with stubbed extractor) and `test_pickup_returns_false_when_no_queued_jobs`; existing `_crash_recovery` + run-loop tests still pass.
+- Container smoke verified end-to-end with a mock Firecrawl on `:13002`: reachability check passes, `POST /api/v1/submit` returns 201, status progresses queued → done within seconds, structured logs include `pipeline_start`, `stage_start`, `extract_complete` (markdown_chars=1900, has_title=true), `stage_end` (duration_ms=7), `pipeline_done`. Contextvars correctly stamp `job_id` + `episode_id` + `stage` on every record.
+
 ### Added (Phase 1 - Project Scaffold)
 
 - Repo layout per the build plan: `backend/app/{api,core,utils,prompts,corrections,reference}`, `backend/tests/`, `data/`.

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -1,0 +1,70 @@
+"""Consistent error envelope per build plan.
+
+All 4xx/5xx responses use ``{error, status, details?}``. 5xx responses log
+the underlying exception with traceback but never leak internal detail to the
+client.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+logger = logging.getLogger("app.api.errors")
+
+
+def envelope(*, status: int, error: str, details: dict[str, Any] | None = None) -> JSONResponse:
+    body: dict[str, Any] = {"error": error, "status": status}
+    if details is not None:
+        body["details"] = details
+    return JSONResponse(status_code=status, content=body)
+
+
+def register(app: FastAPI) -> None:
+    """Install the three handlers that cover every error path."""
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_exception_handler(
+        request: Request, exc: StarletteHTTPException
+    ) -> JSONResponse:
+        # FastAPI's HTTPException already carries a status + detail. If detail
+        # is a dict, treat it as our envelope details; otherwise use the string
+        # as the error message.
+        details: dict[str, Any] | None = None
+        if isinstance(exc.detail, dict):
+            error = exc.detail.get("error", "HTTP error")
+            details = exc.detail.get("details")
+        else:
+            error = str(exc.detail) if exc.detail else "HTTP error"
+        return envelope(status=exc.status_code, error=error, details=details)
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        # exc.errors() can carry non-JSON-safe ctx values (Pattern, Enum,
+        # exception instances) depending on the validator. jsonable_encoder
+        # coerces those into primitives so json.dumps doesn't fall through to
+        # the catch-all 500 handler.
+        return envelope(
+            status=400,
+            error="Validation failed",
+            details={"errors": jsonable_encoder(exc.errors())},
+        )
+
+    @app.exception_handler(Exception)
+    async def _unhandled_handler(request: Request, exc: Exception) -> JSONResponse:
+        logger.exception(
+            "Unhandled exception",
+            extra={
+                "event": "unhandled_exception",
+                "path": str(request.url.path),
+                "method": request.method,
+            },
+        )
+        # Never leak details on 500.
+        return envelope(status=500, error="Internal server error")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,0 +1,12 @@
+"""/api/v1 router aggregation."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.api.v1 import status as status_routes
+from app.api.v1 import submit as submit_routes
+
+router = APIRouter(prefix="/api/v1")
+router.include_router(submit_routes.router)
+router.include_router(status_routes.router)

--- a/backend/app/api/v1/status.py
+++ b/backend/app/api/v1/status.py
@@ -1,0 +1,44 @@
+"""GET /api/v1/status/{job_id} -- look up job state."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.config import Settings, get_settings
+from app.core import database
+from app.services import jobs
+
+router = APIRouter(tags=["jobs"])
+
+
+class StatusResponse(BaseModel):
+    job_id: str
+    episode_id: str
+    url: str
+    status: str
+    stage: str | None
+    error: str | None
+    created_at: str
+    updated_at: str
+
+
+@router.get(
+    "/status/{job_id}",
+    response_model=StatusResponse,
+    summary="Fetch job status",
+)
+def status(
+    job_id: str,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> StatusResponse:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        job = jobs.get_job(conn, job_id)
+    finally:
+        conn.close()
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return StatusResponse(**jobs.job_as_dict(job))

--- a/backend/app/api/v1/submit.py
+++ b/backend/app/api/v1/submit.py
@@ -1,0 +1,87 @@
+"""POST /api/v1/submit -- enqueue an article URL for processing."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
+
+from app.config import Settings, get_settings
+from app.core import database
+from app.services import jobs
+
+router = APIRouter(tags=["jobs"])
+
+
+class SubmitRequest(BaseModel):
+    # extra="forbid" so client-side typos like {"reprcess": true} surface as
+    # 400 Validation failed instead of being silently dropped.
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(
+        description="HTTP/HTTPS URL of the article to ingest.",
+    )
+    reprocess: bool = Field(
+        default=False,
+        description=(
+            "When true and the URL already has an episode/job, wipe the prior "
+            "state and start fresh. Default is to return 409."
+        ),
+    )
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, value: str) -> str:
+        # Validate with AnyHttpUrl semantics but return the exact string the
+        # user submitted so the persisted url/episode_id are stable against the
+        # raw input (pydantic's str(AnyHttpUrl) normalizes host casing and
+        # appends a trailing slash on bare hosts).
+        AnyHttpUrl(value)
+        return value
+
+
+class SubmitResponse(BaseModel):
+    job_id: str
+    episode_id: str
+    status: str
+    replaced_previous: bool = Field(
+        default=False,
+        description="True if reprocess=true and a prior episode/job was deleted.",
+    )
+
+
+@router.post(
+    "/submit",
+    status_code=201,
+    response_model=SubmitResponse,
+    summary="Submit an article URL for processing",
+)
+def submit(
+    body: SubmitRequest,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> SubmitResponse:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        try:
+            result = jobs.create_job(conn, body.url, reprocess=body.reprocess)
+        except jobs.DuplicateSubmissionError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "Episode already exists",
+                    "details": {
+                        "episode_id": exc.episode_id,
+                        "reason": exc.reason,
+                        "url": body.url,
+                    },
+                },
+            ) from exc
+    finally:
+        conn.close()
+    return SubmitResponse(
+        job_id=result.job.id,
+        episode_id=result.job.episode_id,
+        status=result.job.status,
+        replaced_previous=result.replaced_previous,
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
 
     # Queue / HTTP / worker.
     QUEUE_POLL_INTERVAL_SECONDS: float = 2.0
-    JOB_TIMEOUT_SECONDS: int = 1800
+    JOB_TIMEOUT_SECONDS: float = 1800
     WEB_WORKERS: int = 2
 
     # Logging.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,9 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from app.api import errors as error_handlers
 from app.api.health import router as health_router
+from app.api.v1.router import router as v1_router
 from app.config import get_settings
 from app.startup import bootstrap
 from app.version import __version__
@@ -33,6 +35,8 @@ def create_app() -> FastAPI:
         openapi_url="/api/v1/openapi.json",
     )
     app.include_router(health_router)
+    app.include_router(v1_router)
+    error_handlers.register(app)
     return app
 
 

--- a/backend/app/services/extraction.py
+++ b/backend/app/services/extraction.py
@@ -1,0 +1,151 @@
+"""Firecrawl extraction client.
+
+Wraps the self-hosted Firecrawl ``/v1/scrape`` endpoint with tenacity retries on
+transient failures and a minimum-length guard. Other stages of the pipeline see
+a clean ``ExtractionResult`` or a typed exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from app.config import Settings
+
+logger = logging.getLogger("app.services.extraction")
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """Parsed Firecrawl response. ``markdown`` is the cleaned-page body; metadata
+    holds anything later phases may want (title, og:image, author)."""
+
+    markdown: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ExtractionError(Exception):
+    """Base class so callers can do a single except for any extraction failure."""
+
+
+class ExtractionTransientError(ExtractionError):
+    """5xx, connection refused, timeout. Tenacity retries these."""
+
+
+class ExtractionPermanentError(ExtractionError):
+    """4xx, malformed response, or any other non-retryable failure."""
+
+
+class ExtractionTooShortError(ExtractionPermanentError):
+    """Markdown returned was below ``MIN_EXTRACTION_CHARS``."""
+
+
+async def extract(url: str, settings: Settings) -> ExtractionResult:
+    """Scrape ``url`` via Firecrawl and validate the result.
+
+    Raises:
+        ExtractionTransientError: every retry exhausted on a retryable failure.
+        ExtractionPermanentError: 4xx, malformed JSON, or other non-retryable.
+        ExtractionTooShortError: response shorter than ``MIN_EXTRACTION_CHARS``.
+    """
+
+    endpoint = f"{settings.FIRECRAWL_URL.rstrip('/')}/v1/scrape"
+    payload = {"url": url, "formats": ["markdown"]}
+    timeout = httpx.Timeout(settings.FIRECRAWL_TIMEOUT_SECONDS)
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            response = await _post_with_retry(client, endpoint, payload, settings)
+        except RetryError as exc:
+            inner = exc.last_attempt.exception()
+            if isinstance(inner, ExtractionError):
+                raise inner from exc
+            raise ExtractionTransientError(f"Firecrawl retries exhausted: {inner}") from exc
+
+    body = _parse_response(response, url)
+    data = body.get("data") or {}
+    if not isinstance(data, dict):
+        raise ExtractionPermanentError(
+            f"Firecrawl returned non-object `data` for {url}: {type(data).__name__}"
+        )
+    markdown = data.get("markdown") or ""
+    metadata = data.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    if len(markdown) < settings.MIN_EXTRACTION_CHARS:
+        raise ExtractionTooShortError(
+            f"Extracted markdown is {len(markdown)} chars, "
+            f"below MIN_EXTRACTION_CHARS={settings.MIN_EXTRACTION_CHARS}"
+        )
+
+    return ExtractionResult(markdown=markdown, metadata=metadata)
+
+
+async def _post_with_retry(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    payload: dict[str, Any],
+    settings: Settings,
+) -> httpx.Response:
+    retrying = AsyncRetrying(
+        stop=stop_after_attempt(settings.FIRECRAWL_RETRY_COUNT),
+        wait=wait_exponential(
+            multiplier=settings.FIRECRAWL_BACKOFF_BASE_SECONDS,
+            min=settings.FIRECRAWL_BACKOFF_BASE_SECONDS,
+        ),
+        retry=retry_if_exception_type(ExtractionTransientError),
+        reraise=False,
+    )
+    async for attempt in retrying:
+        with attempt:
+            try:
+                response = await client.post(endpoint, json=payload)
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                raise ExtractionTransientError(f"Firecrawl unreachable: {exc}") from exc
+            _raise_for_status(response)
+        if attempt.retry_state.outcome and not attempt.retry_state.outcome.failed:
+            return response
+    # AsyncRetrying with reraise=False either returns from inside the `with`
+    # block (success) or raises RetryError (caught by the caller); unreachable
+    # in practice but the type checker wants a terminal return/raise.
+    raise ExtractionTransientError("Firecrawl retry loop exited without a response")
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    if response.is_server_error:
+        raise ExtractionTransientError(
+            f"Firecrawl returned {response.status_code}: {response.text[:200]}"
+        )
+    if response.is_client_error:
+        raise ExtractionPermanentError(
+            f"Firecrawl rejected request ({response.status_code}): {response.text[:200]}"
+        )
+
+
+def _parse_response(response: httpx.Response, url: str) -> dict[str, Any]:
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ExtractionPermanentError(
+            f"Firecrawl returned non-JSON body for {url}: {exc}"
+        ) from exc
+    if not isinstance(body, dict):
+        raise ExtractionPermanentError(
+            f"Firecrawl returned non-object JSON for {url}: {type(body).__name__}"
+        )
+    if not body.get("success", False):
+        raise ExtractionPermanentError(
+            f"Firecrawl returned success=false for {url}: {body.get('error', '<no error>')}"
+        )
+    return body

--- a/backend/app/services/jobs.py
+++ b/backend/app/services/jobs.py
@@ -1,0 +1,238 @@
+"""Job table helpers.
+
+Every mutation here bumps ``updated_at`` explicitly (no triggers). Callers
+pass an open sqlite3 connection so the surrounding code controls transaction
+boundaries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sqlite3
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger("app.services.jobs")
+
+JobStatus = str  # queued | processing | done | failed
+JobStage = str  # extract | cleanup | corrections | chunk | tts | audio | artwork | transcript | finalize | done
+
+
+@dataclass(frozen=True)
+class Job:
+    id: str
+    url: str
+    episode_id: str
+    status: JobStatus
+    stage: JobStage | None
+    error: str | None
+    created_at: str
+    updated_at: str
+
+
+def compute_episode_id(url: str) -> str:
+    """MD5(url) truncated to 12 hex chars. Deterministic per URL."""
+
+    return hashlib.md5(url.encode("utf-8")).hexdigest()[:12]
+
+
+def _row_to_job(row: sqlite3.Row) -> Job:
+    return Job(
+        id=row["id"],
+        url=row["url"],
+        episode_id=row["episode_id"],
+        status=row["status"],
+        stage=row["stage"],
+        error=row["error"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def get_job(conn: sqlite3.Connection, job_id: str) -> Job | None:
+    row = conn.execute(
+        "SELECT id, url, episode_id, status, stage, error, created_at, updated_at "
+        "FROM jobs WHERE id = ?",
+        (job_id,),
+    ).fetchone()
+    return _row_to_job(row) if row else None
+
+
+def get_job_by_episode_id(
+    conn: sqlite3.Connection, episode_id: str, *, statuses: tuple[str, ...] | None = None
+) -> Job | None:
+    """Return the most recent job for ``episode_id``, optionally filtered by status."""
+
+    base = (
+        "SELECT id, url, episode_id, status, stage, error, created_at, updated_at "
+        "FROM jobs WHERE episode_id = ?"
+    )
+    params: tuple = (episode_id,)
+    if statuses:
+        placeholders = ",".join("?" for _ in statuses)
+        base += f" AND status IN ({placeholders})"
+        params += statuses
+    base += " ORDER BY created_at DESC LIMIT 1"
+    row = conn.execute(base, params).fetchone()
+    return _row_to_job(row) if row else None
+
+
+def episode_exists(conn: sqlite3.Connection, episode_id: str) -> bool:
+    row = conn.execute("SELECT 1 FROM episodes WHERE id = ?", (episode_id,)).fetchone()
+    return row is not None
+
+
+@dataclass(frozen=True)
+class CreateJobResult:
+    job: Job
+    """The newly created job row."""
+    replaced_previous: bool
+    """True if ``reprocess=True`` removed prior job rows / episode for this URL."""
+
+
+class DuplicateSubmissionError(Exception):
+    """Raised when a non-reprocess submission collides with an existing episode
+    or with an in-flight job. The submit endpoint converts this to a 409."""
+
+    def __init__(self, episode_id: str, reason: str) -> None:
+        super().__init__(f"duplicate submission for episode_id={episode_id}: {reason}")
+        self.episode_id = episode_id
+        self.reason = reason
+
+
+def create_job(conn: sqlite3.Connection, url: str, *, reprocess: bool = False) -> CreateJobResult:
+    """Insert a new ``queued`` job for ``url``.
+
+    All the duplicate-detection + delete + insert runs inside a single
+    BEGIN IMMEDIATE transaction so two concurrent submits for the same URL can
+    only result in one INSERT, and a failure mid-DELETE in the reprocess path
+    leaves the DB exactly as it started.
+
+    Duplicate handling per build plan:
+    - If an episode already exists for this URL's episode_id, reject unless
+      reprocess=True (in which case wipe the prior episode + jobs and proceed).
+    - If a queued/processing job already exists for this episode_id, reject
+      regardless of reprocess: don't race two pipelines against the same URL.
+    """
+
+    episode_id = compute_episode_id(url)
+    job_id = str(uuid.uuid4())
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        in_flight = get_job_by_episode_id(conn, episode_id, statuses=("queued", "processing"))
+        if in_flight is not None:
+            conn.execute("ROLLBACK")
+            raise DuplicateSubmissionError(
+                episode_id, f"job {in_flight.id} is already {in_flight.status}"
+            )
+
+        has_episode = episode_exists(conn, episode_id)
+        replaced = False
+        if has_episode and not reprocess:
+            conn.execute("ROLLBACK")
+            raise DuplicateSubmissionError(episode_id, "episode already exists")
+        if has_episode and reprocess:
+            # Episodes hold a FK to jobs(id); delete episodes first so the
+            # subsequent jobs DELETE can't trip the ON DELETE behavior.
+            conn.execute("DELETE FROM episodes WHERE id = ?", (episode_id,))
+            conn.execute("DELETE FROM jobs WHERE episode_id = ?", (episode_id,))
+            replaced = True
+
+        conn.execute(
+            "INSERT INTO jobs (id, url, episode_id, status) VALUES (?, ?, ?, 'queued')",
+            (job_id, url, episode_id),
+        )
+        conn.execute("COMMIT")
+    except DuplicateSubmissionError:
+        raise
+    except Exception:
+        with suppress(sqlite3.OperationalError):
+            conn.execute("ROLLBACK")
+        raise
+
+    job = get_job(conn, job_id)
+    assert job is not None  # just inserted
+    logger.info(
+        "Job created",
+        extra={
+            "event": "job_created",
+            "job_id": job_id,
+            "episode_id": episode_id,
+            "url": url,
+            "reprocess": reprocess,
+            "replaced_previous": replaced,
+        },
+    )
+    return CreateJobResult(job=job, replaced_previous=replaced)
+
+
+def claim_next_queued(conn: sqlite3.Connection) -> Job | None:
+    """Atomically move the oldest queued job to ``processing`` and return it.
+
+    Wraps SELECT + UPDATE in a single transaction so two workers (or the worker
+    racing with a manual SQL edit) can't both claim the same job. Returns None
+    if nothing is queued.
+    """
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        row = conn.execute(
+            "SELECT id FROM jobs WHERE status = 'queued' ORDER BY created_at ASC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            conn.execute("COMMIT")
+            return None
+        conn.execute(
+            "UPDATE jobs SET status = 'processing', "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+            (row["id"],),
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        # SQLite auto-aborts on commit failure; suppress the secondary
+        # "no transaction is active" so the original error propagates.
+        with suppress(sqlite3.OperationalError):
+            conn.execute("ROLLBACK")
+        raise
+    return get_job(conn, row["id"])
+
+
+def set_stage(conn: sqlite3.Connection, job_id: str, stage: JobStage) -> None:
+    conn.execute(
+        "UPDATE jobs SET stage = ?, "
+        "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        (stage, job_id),
+    )
+
+
+def mark_done(conn: sqlite3.Connection, job_id: str, *, final_stage: JobStage) -> None:
+    conn.execute(
+        "UPDATE jobs SET status = 'done', stage = ?, error = NULL, "
+        "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        (final_stage, job_id),
+    )
+
+
+def mark_failed(conn: sqlite3.Connection, job_id: str, *, stage: JobStage, error: str) -> None:
+    conn.execute(
+        "UPDATE jobs SET status = 'failed', stage = ?, error = ?, "
+        "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        (stage, error, job_id),
+    )
+
+
+def job_as_dict(job: Job) -> dict[str, Any]:
+    return {
+        "job_id": job.id,
+        "episode_id": job.episode_id,
+        "url": job.url,
+        "status": job.status,
+        "stage": job.stage,
+        "error": job.error,
+        "created_at": job.created_at,
+        "updated_at": job.updated_at,
+    }

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -1,0 +1,226 @@
+"""Job processing pipeline orchestrator.
+
+Phase 2 wires only the extract stage. Subsequent phases append cleanup,
+chunk, tts, audio, artwork, transcript, finalize.
+
+Conventions enforced here:
+- Every stage writes its name to ``jobs.stage`` BEFORE doing any work, so the
+  job-timeout path can report exactly which stage was running.
+- Stage start/end/failure emit structured log records with ``job_id`` +
+  ``episode_id`` stamped via contextvars.
+- The whole job runs under ``asyncio.wait_for(JOB_TIMEOUT_SECONDS)``; the
+  timeout handler reads the last persisted stage and writes a clear error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import contextmanager
+from typing import Any
+
+from app.config import Settings
+from app.core import database
+from app.services import extraction, jobs
+from app.utils.logging import episode_id_ctx, job_id_ctx, stage_ctx
+
+logger = logging.getLogger("app.services.pipeline")
+
+
+@contextmanager
+def _job_context(job: jobs.Job):
+    tokens = (
+        job_id_ctx.set(job.id),
+        episode_id_ctx.set(job.episode_id),
+    )
+    try:
+        yield
+    finally:
+        episode_id_ctx.reset(tokens[1])
+        job_id_ctx.reset(tokens[0])
+
+
+@contextmanager
+def _stage_context(stage_name: str):
+    token = stage_ctx.set(stage_name)
+    try:
+        yield
+    finally:
+        stage_ctx.reset(token)
+
+
+async def process_job(job: jobs.Job, settings: Settings) -> None:
+    """Run the configured pipeline stages against ``job``.
+
+    Phase 2: extract only, then mark done. On any failure write
+    ``stage`` + ``error`` and set status=failed. On timeout report the last
+    persisted stage in the error message.
+    """
+
+    with _job_context(job):
+        logger.info("Pipeline starting", extra={"event": "pipeline_start"})
+        try:
+            await asyncio.wait_for(
+                _run_stages(job, settings),
+                timeout=settings.JOB_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            _finalize_failure(
+                job.id,
+                settings,
+                error_template=(
+                    f"job exceeded JOB_TIMEOUT_SECONDS={settings.JOB_TIMEOUT_SECONDS} "
+                    f"during stage {{stage}}"
+                ),
+                log_message="Pipeline timed out",
+                log_event="pipeline_timeout",
+                log_level=logging.WARNING,
+                extra_log_fields={"timeout_seconds": settings.JOB_TIMEOUT_SECONDS},
+            )
+        except Exception as exc:
+            _finalize_failure(
+                job.id,
+                settings,
+                error_template=str(exc),
+                log_message="Pipeline failed",
+                log_event="pipeline_failed",
+                log_level=logging.ERROR,
+                with_exc_info=True,
+            )
+        else:
+            logger.info("Pipeline finished", extra={"event": "pipeline_done"})
+
+
+def _finalize_failure(
+    job_id: str,
+    settings: Settings,
+    *,
+    error_template: str,
+    log_message: str,
+    log_event: str,
+    log_level: int,
+    with_exc_info: bool = False,
+    extra_log_fields: dict[str, Any] | None = None,
+) -> None:
+    """Shared exit path for both the timeout and generic-exception branches.
+
+    Reads the last persisted stage (or "unknown"), writes the failure row, and
+    emits the structured log line. Wraps the DB write in try/except so a
+    secondary failure (locked DB, disk full) can't mask the original.
+    """
+
+    try:
+        last_stage = _last_stage(job_id, settings) or "unknown"
+    except Exception:
+        last_stage = "unknown"
+        logger.exception(
+            "Failed to read last stage during error finalization",
+            extra={"event": "finalize_read_failed"},
+        )
+
+    error_message = error_template.format(stage=last_stage)
+    try:
+        _persist_failure(job_id, stage=last_stage, error=error_message, settings=settings)
+    except Exception:
+        logger.exception(
+            "Failed to persist job failure",
+            extra={"event": "finalize_persist_failed", "stage": last_stage},
+        )
+
+    fields = {"event": log_event, "stage": last_stage}
+    if extra_log_fields:
+        fields.update(extra_log_fields)
+    logger.log(log_level, log_message, extra=fields, exc_info=with_exc_info)
+
+
+async def _run_stages(job: jobs.Job, settings: Settings) -> None:
+    """Phase 2 pipeline: a single extract stage."""
+
+    await _run_stage("extract", lambda: _stage_extract(job, settings), job.id, settings)
+    _mark_done(job.id, final_stage="extract", settings=settings)
+
+
+async def _run_stage(
+    name: str,
+    body: Callable[[], Awaitable[Any]],
+    job_id: str,
+    settings: Settings,
+) -> Any:
+    """Run ``body`` as the named stage, persisting ``stage=name`` first and
+    emitting stage_start / stage_end structured logs."""
+
+    _set_stage(job_id, name, settings)
+    with _stage_context(name):
+        started = time.perf_counter()
+        logger.info("Stage start", extra={"event": "stage_start"})
+        try:
+            result = await body()
+        except BaseException:
+            # BaseException covers asyncio.CancelledError (timeout) so the
+            # stage_failed log fires for cancelled stages too.
+            duration_ms = int((time.perf_counter() - started) * 1000)
+            logger.exception(
+                "Stage failed",
+                extra={"event": "stage_failed", "duration_ms": duration_ms},
+            )
+            raise
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        logger.info(
+            "Stage end",
+            extra={"event": "stage_end", "duration_ms": duration_ms},
+        )
+        return result
+
+
+async def _stage_extract(job: jobs.Job, settings: Settings) -> extraction.ExtractionResult:
+    result = await extraction.extract(job.url, settings)
+    logger.info(
+        "Extraction succeeded",
+        extra={
+            "event": "extract_complete",
+            "markdown_chars": len(result.markdown),
+            "has_title": "title" in result.metadata,
+        },
+    )
+    return result
+
+
+# --- DB helpers --------------------------------------------------------------
+# All of these open and close their own connection. The worker process is the
+# only writer in this pipeline, but each helper keeps its scope tight so a
+# long-running stage doesn't hold a write lock.
+
+
+def _set_stage(job_id: str, stage: str, settings: Settings) -> None:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        jobs.set_stage(conn, job_id, stage)
+    finally:
+        conn.close()
+
+
+def _mark_done(job_id: str, *, final_stage: str, settings: Settings) -> None:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        jobs.mark_done(conn, job_id, final_stage=final_stage)
+    finally:
+        conn.close()
+
+
+def _persist_failure(job_id: str, *, stage: str, error: str, settings: Settings) -> None:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        jobs.mark_failed(conn, job_id, stage=stage, error=error)
+    finally:
+        conn.close()
+
+
+def _last_stage(job_id: str, settings: Settings) -> str | None:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        job = jobs.get_job(conn, job_id)
+    finally:
+        conn.close()
+    return job.stage if job else None

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -1,0 +1,92 @@
+"""Startup reachability checks.
+
+Each external dependency the pipeline needs is probed before the worker begins
+processing. A failure here is fatal: the process exits non-zero so the
+container restart loop surfaces the problem instead of every job failing in
+the same way mid-stage.
+
+Phase 2 only checks Firecrawl. The LLM probe lands in Phase 3 and the TTS
+wrapper probe in Phase 4 -- see the table in build-plan.md "Startup
+Reachability Checks".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from app.config import Settings
+
+logger = logging.getLogger("app.services.reachability")
+
+
+class ReachabilityError(RuntimeError):
+    """Raised when a required external dependency is unreachable at startup."""
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+async def check_firecrawl(settings: Settings, *, timeout: float = 5.0) -> CheckResult:
+    """Probe Firecrawl with whichever health path it exposes.
+
+    Self-hosted Firecrawl historically responds at ``GET /`` with a JSON banner,
+    while some versions expose ``GET /v1/health``. We try the well-known
+    endpoints in order and treat the first 2xx as healthy. A non-2xx from the
+    last candidate is reported as the failure detail.
+    """
+
+    base = settings.FIRECRAWL_URL.rstrip("/")
+    candidates = (f"{base}/v1/health", f"{base}/health", f"{base}/")
+    last_detail = "no endpoint responded"
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for endpoint in candidates:
+            try:
+                response = await client.get(endpoint)
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                last_detail = f"unreachable ({exc.__class__.__name__}: {exc})"
+                continue
+            if response.is_success:
+                return CheckResult(
+                    name="firecrawl",
+                    ok=True,
+                    detail=f"HTTP {response.status_code} from {endpoint.split(base)[1] or '/'}",
+                )
+            last_detail = f"HTTP {response.status_code}: {response.text[:120]}"
+
+    return CheckResult(name="firecrawl", ok=False, detail=last_detail)
+
+
+async def run_all(settings: Settings) -> list[CheckResult]:
+    """Run every Phase-appropriate check.
+
+    Logs each result and raises ``ReachabilityError`` if any check failed. The
+    worker bootstrap calls this; the FastAPI lifespan doesn't (so reviewers
+    using the API for /health while a dependency is down still get a useful
+    503 instead of a refusing-to-start container).
+    """
+
+    results: list[CheckResult] = [await check_firecrawl(settings)]
+    failed = [r for r in results if not r.ok]
+    for result in results:
+        logger.info(
+            "Reachability check",
+            extra={
+                "event": "reachability_check",
+                "stage": "startup",
+                "check": result.name,
+                "ok": result.ok,
+                "detail": result.detail,
+            },
+        )
+    if failed:
+        names = ", ".join(r.name for r in failed)
+        raise ReachabilityError(f"reachability checks failed: {names}")
+    return results

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,17 +1,22 @@
 """Queue worker process.
 
-Phase 1: polling loop that performs crash recovery at startup, then idles. The
-pipeline stages (extract, cleanup, tts, ...) are wired up in later phases.
+Polls the jobs table for ``status='queued'`` rows. Single in-flight job: the
+pipeline runs sequentially and the next poll only happens after the previous
+job finishes (or fails). Crash recovery and reachability checks gate the
+polling loop.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import signal
+import sys
 
-from app.config import get_settings
+from app.config import Settings, get_settings
 from app.core import database
+from app.services import jobs, pipeline, reachability
 from app.startup import bootstrap
 
 logger = logging.getLogger("app.worker")
@@ -30,9 +35,38 @@ async def _crash_recovery(data_dir) -> None:
         conn.close()
 
 
+async def _pickup_once(settings: Settings) -> jobs.Job | None:
+    """Claim the oldest queued job, if any."""
+
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        return jobs.claim_next_queued(conn)
+    finally:
+        conn.close()
+
+
+async def _process_one(settings: Settings) -> bool:
+    """Pick up and run one job. Returns True if a job was processed."""
+
+    job = await _pickup_once(settings)
+    if job is None:
+        return False
+    await pipeline.process_job(job, settings)
+    return True
+
+
 async def run() -> None:
     settings = get_settings()
     bootstrap(settings, process_label="worker")
+
+    try:
+        await reachability.run_all(settings)
+    except reachability.ReachabilityError as exc:
+        logger.error(
+            "Startup reachability checks failed; exiting",
+            extra={"event": "reachability_fatal", "stage": "startup", "error": str(exc)},
+        )
+        sys.exit(1)
 
     shutdown = asyncio.Event()
     loop = asyncio.get_running_loop()
@@ -53,10 +87,22 @@ async def run() -> None:
 
     poll_interval = settings.QUEUE_POLL_INTERVAL_SECONDS
     while not shutdown.is_set():
+        # Anything that escapes process_job (DB locked during pickup, OSError
+        # on the data dir, ...) must not kill the worker. Log it and back off
+        # one poll interval so we don't spin against a hard failure.
         try:
-            await asyncio.wait_for(shutdown.wait(), timeout=poll_interval)
-        except TimeoutError:
+            processed = await _process_one(settings)
+        except Exception:
+            logger.exception(
+                "Worker iteration failed; backing off",
+                extra={"event": "worker_iteration_failed"},
+            )
+            processed = False
+        if processed:
+            # Loop right back: a job may have arrived while we were working.
             continue
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(shutdown.wait(), timeout=poll_interval)
 
     logger.info("Worker stopped", extra={"event": "worker_stopped"})
 

--- a/backend/tests/test_api_v1.py
+++ b/backend/tests/test_api_v1.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from app.core import database
+from app.main import create_app
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(env: Path) -> TestClient:
+    database.run_migrations(env)
+    return TestClient(create_app())
+
+
+def test_submit_returns_201_with_job_id_and_episode_id(client: TestClient) -> None:
+    with client:
+        response = client.post("/api/v1/submit", json={"url": "https://example.test/article"})
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["status"] == "queued"
+    assert len(body["episode_id"]) == 12
+    assert body["job_id"]
+    assert body["replaced_previous"] is False
+
+
+def test_submit_rejects_invalid_url_with_400(client: TestClient) -> None:
+    with client:
+        response = client.post("/api/v1/submit", json={"url": "not-a-url"})
+    assert response.status_code == 400
+    body = response.json()
+    assert body["status"] == 400
+    assert body["error"] == "Validation failed"
+    assert "details" in body
+
+
+def test_submit_rejects_inflight_duplicate_with_409(client: TestClient) -> None:
+    with client:
+        first = client.post("/api/v1/submit", json={"url": "https://example.test/dup"})
+        assert first.status_code == 201
+        second = client.post("/api/v1/submit", json={"url": "https://example.test/dup"})
+    assert second.status_code == 409
+    body = second.json()
+    assert body["status"] == 409
+    assert body["error"] == "Episode already exists"
+    assert body["details"]["episode_id"] == first.json()["episode_id"]
+
+
+def test_submit_reprocess_allows_resubmit_after_episode_landed(
+    client: TestClient, env: Path
+) -> None:
+    with client:
+        first = client.post("/api/v1/submit", json={"url": "https://example.test/reproc"})
+        first_episode_id = first.json()["episode_id"]
+        # Simulate Phase 7+ creating an episode + finishing the job.
+        conn = database.connect(database.db_path(env))
+        try:
+            conn.execute(
+                "UPDATE jobs SET status='done', stage='done' WHERE id = ?",
+                (first.json()["job_id"],),
+            )
+            conn.execute(
+                "INSERT INTO episodes (id, original_url) VALUES (?, ?)",
+                (first_episode_id, "https://example.test/reproc"),
+            )
+        finally:
+            conn.close()
+
+        # Default reprocess=false -> 409
+        dup = client.post("/api/v1/submit", json={"url": "https://example.test/reproc"})
+        assert dup.status_code == 409
+
+        # reprocess=true -> 201 + replaced_previous=True
+        again = client.post(
+            "/api/v1/submit",
+            json={"url": "https://example.test/reproc", "reprocess": True},
+        )
+    assert again.status_code == 201
+    body = again.json()
+    assert body["episode_id"] == first_episode_id
+    assert body["replaced_previous"] is True
+
+
+def test_status_returns_200_for_existing_job(client: TestClient) -> None:
+    with client:
+        submit = client.post("/api/v1/submit", json={"url": "https://example.test/status"})
+        job_id = submit.json()["job_id"]
+        status = client.get(f"/api/v1/status/{job_id}")
+    assert status.status_code == 200
+    body = status.json()
+    assert body["job_id"] == job_id
+    assert body["status"] == "queued"
+    assert body["url"] == "https://example.test/status"
+    assert body["stage"] is None
+    assert body["error"] is None
+
+
+def test_status_returns_404_for_missing_job(client: TestClient) -> None:
+    with client:
+        response = client.get("/api/v1/status/no-such-job")
+    assert response.status_code == 404
+    body = response.json()
+    assert body["status"] == 404
+    assert body["error"] == "Job not found"
+
+
+def test_submit_rejects_unknown_fields_with_400(client: TestClient) -> None:
+    with client:
+        response = client.post(
+            "/api/v1/submit",
+            json={"url": "https://example.test/typo", "reprcess": True},
+        )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"] == "Validation failed"
+
+
+def test_submit_preserves_raw_url_through_to_status(client: TestClient) -> None:
+    """AnyHttpUrl normalizes (host lowercasing, trailing slash); the submit
+    handler intentionally stores the user's exact string so episode_id and the
+    returned URL match what the user sent."""
+
+    with client:
+        raw = "https://Example.test/Article?id=42"
+        submit = client.post("/api/v1/submit", json={"url": raw})
+        assert submit.status_code == 201
+        job_id = submit.json()["job_id"]
+        status = client.get(f"/api/v1/status/{job_id}")
+    assert status.json()["url"] == raw
+
+
+def test_reprocess_still_409s_when_a_concurrent_inflight_job_exists(
+    client: TestClient, env: Path
+) -> None:
+    """The in_flight guard runs BEFORE the reprocess wipe; even with
+    reprocess=True, a queued/processing job for the same URL must reject."""
+
+    with client:
+        first = client.post(
+            "/api/v1/submit",
+            json={"url": "https://example.test/race"},
+        )
+        assert first.status_code == 201
+
+        again = client.post(
+            "/api/v1/submit",
+            json={"url": "https://example.test/race", "reprocess": True},
+        )
+    assert again.status_code == 409
+    assert "already queued" in again.json()["details"]["reason"]
+
+
+def test_status_returns_failed_job_with_stage_and_error(client: TestClient, env: Path) -> None:
+    with client:
+        submit = client.post("/api/v1/submit", json={"url": "https://example.test/failed"})
+        job_id = submit.json()["job_id"]
+        # Simulate the worker pipeline marking the job failed.
+        conn = database.connect(database.db_path(env))
+        try:
+            conn.execute(
+                "UPDATE jobs SET status='failed', stage='extract', "
+                "error='Firecrawl said no' WHERE id = ?",
+                (job_id,),
+            )
+        finally:
+            conn.close()
+        response = client.get(f"/api/v1/status/{job_id}")
+    body = response.json()
+    assert body["status"] == "failed"
+    assert body["stage"] == "extract"
+    assert body["error"] == "Firecrawl said no"
+
+
+def test_unhandled_exception_returns_500_envelope_without_leaking_details(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 'never leak details on 500' contract gets a dedicated test by
+    forcing an unhandled exception inside the status endpoint."""
+
+    database.run_migrations(env)
+    # TestClient re-raises server errors by default; flip the flag so the
+    # envelope returned by the catch-all handler is observable.
+    raw_client = TestClient(create_app(), raise_server_exceptions=False)
+    with raw_client as client:
+        submit = client.post("/api/v1/submit", json={"url": "https://example.test/boom"})
+        job_id = submit.json()["job_id"]
+
+        from app.services import jobs
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("super-secret-internal-detail")
+
+        monkeypatch.setattr(jobs, "get_job", _boom)
+        response = client.get(f"/api/v1/status/{job_id}")
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"] == "Internal server error"
+    assert "super-secret-internal-detail" not in str(body)
+    assert "details" not in body or body.get("details") is None

--- a/backend/tests/test_extraction.py
+++ b/backend/tests/test_extraction.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from app.config import get_settings
+from app.services import extraction
+
+
+@pytest.fixture
+def fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force FIRECRAWL_BACKOFF_BASE_SECONDS=0 so tenacity's exponential wait
+    returns immediately. Tests that exercise the retry loop request this so
+    they don't sleep for whole seconds while waiting for retries."""
+
+    monkeypatch.setenv("FIRECRAWL_BACKOFF_BASE_SECONDS", "0")
+    monkeypatch.setenv("FIRECRAWL_RETRY_COUNT", "3")
+
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+
+def _ok_response(markdown: str = "x" * 1000) -> httpx.Response:
+    return httpx.Response(
+        200,
+        content=json.dumps(
+            {"success": True, "data": {"markdown": markdown, "metadata": {"title": "ok"}}}
+        ).encode(),
+        headers={"content-type": "application/json"},
+    )
+
+
+def _patch_async_client(monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport) -> None:
+    """Swap httpx.AsyncClient for a constructor that pins the test transport."""
+
+    original = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+def _stub_transport(*responses) -> httpx.MockTransport:
+    """Cycle through the given responses, each consumed once."""
+
+    iterator = iter(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        try:
+            value = next(iterator)
+        except StopIteration as exc:
+            raise AssertionError("Extraction made more HTTP calls than expected") from exc
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    return httpx.MockTransport(handler)
+
+
+async def test_extract_happy_path(env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _stub_transport(_ok_response("body " * 200))
+
+    _patch_async_client(monkeypatch, transport)
+
+    result = await extraction.extract("https://example.test/article", get_settings())
+    assert result.markdown.startswith("body ")
+    assert result.metadata["title"] == "ok"
+
+
+async def test_extract_retries_on_5xx_then_succeeds(
+    env: Path, monkeypatch: pytest.MonkeyPatch, fast_backoff
+) -> None:
+    transport = _stub_transport(
+        httpx.Response(500, text="boom"),
+        httpx.Response(503, text="still boom"),
+        _ok_response("body " * 200),
+    )
+    _patch_async_client(monkeypatch, transport)
+
+    result = await extraction.extract("https://example.test/article", get_settings())
+    assert result.markdown.startswith("body ")
+
+
+async def test_extract_does_not_retry_on_4xx(
+    env: Path, monkeypatch: pytest.MonkeyPatch, fast_backoff
+) -> None:
+    transport = _stub_transport(httpx.Response(400, text="malformed"))
+    _patch_async_client(monkeypatch, transport)
+
+    with pytest.raises(extraction.ExtractionPermanentError, match="400"):
+        await extraction.extract("https://example.test/article", get_settings())
+
+
+async def test_extract_exhausts_retries_on_persistent_5xx(
+    env: Path, monkeypatch: pytest.MonkeyPatch, fast_backoff
+) -> None:
+    transport = _stub_transport(
+        httpx.Response(500, text="boom"),
+        httpx.Response(500, text="boom"),
+        httpx.Response(500, text="boom"),
+    )
+    _patch_async_client(monkeypatch, transport)
+
+    with pytest.raises(extraction.ExtractionTransientError):
+        await extraction.extract("https://example.test/article", get_settings())
+
+
+async def test_extract_rejects_short_markdown(env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _stub_transport(_ok_response("tiny"))
+    _patch_async_client(monkeypatch, transport)
+
+    with pytest.raises(extraction.ExtractionTooShortError):
+        await extraction.extract("https://example.test/article", get_settings())
+
+
+async def test_extract_rejects_success_false(
+    env: Path, monkeypatch: pytest.MonkeyPatch, fast_backoff
+) -> None:
+    response = httpx.Response(
+        200,
+        content=json.dumps({"success": False, "error": "scrape failed"}).encode(),
+        headers={"content-type": "application/json"},
+    )
+    transport = _stub_transport(response)
+    _patch_async_client(monkeypatch, transport)
+
+    with pytest.raises(extraction.ExtractionPermanentError, match="success=false"):
+        await extraction.extract("https://example.test/article", get_settings())

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from app.config import get_settings
+from app.core import database
+from app.services import extraction, jobs, pipeline
+
+
+def _seed_job(env: Path, url: str = "https://example.test/article") -> jobs.Job:
+    conn = database.connect(database.db_path(env))
+    try:
+        jobs.create_job(conn, url)
+        # Move it to processing so process_job sees the same state the worker would.
+        claimed = jobs.claim_next_queued(conn)
+        assert claimed is not None
+        return claimed
+    finally:
+        conn.close()
+
+
+def _job_after(env: Path, job_id: str) -> jobs.Job:
+    conn = database.connect(database.db_path(env))
+    try:
+        job = jobs.get_job(conn, job_id)
+    finally:
+        conn.close()
+    assert job is not None
+    return job
+
+
+async def test_pipeline_marks_job_done_on_success(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database.run_migrations(env)
+
+    async def _fake_extract(url, settings):
+        return extraction.ExtractionResult(markdown="x" * 1000, metadata={})
+
+    monkeypatch.setattr(extraction, "extract", _fake_extract)
+
+    job = _seed_job(env)
+    await pipeline.process_job(job, get_settings())
+
+    after = _job_after(env, job.id)
+    assert after.status == "done"
+    assert after.stage == "extract"
+    assert after.error is None
+
+
+async def test_pipeline_marks_failed_with_stage_and_error_on_extraction_failure(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database.run_migrations(env)
+
+    async def _bad_extract(url, settings):
+        raise extraction.ExtractionPermanentError("Firecrawl said no")
+
+    monkeypatch.setattr(extraction, "extract", _bad_extract)
+
+    job = _seed_job(env)
+    await pipeline.process_job(job, get_settings())
+
+    after = _job_after(env, job.id)
+    assert after.status == "failed"
+    assert after.stage == "extract"
+    assert after.error is not None
+    assert "Firecrawl said no" in after.error
+
+
+async def test_pipeline_marks_failed_with_timeout_error_on_job_timeout(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database.run_migrations(env)
+
+    async def _slow_extract(url, settings):
+        await asyncio.sleep(2)
+        return extraction.ExtractionResult(markdown="x" * 1000, metadata={})
+
+    monkeypatch.setattr(extraction, "extract", _slow_extract)
+    monkeypatch.setenv("JOB_TIMEOUT_SECONDS", "0.05")
+    get_settings.cache_clear()
+
+    job = _seed_job(env)
+    await pipeline.process_job(job, get_settings())
+
+    after = _job_after(env, job.id)
+    assert after.status == "failed"
+    assert after.stage == "extract"
+    assert "JOB_TIMEOUT_SECONDS" in (after.error or "")

--- a/backend/tests/test_reachability.py
+++ b/backend/tests/test_reachability.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from app.config import get_settings
+from app.services import reachability
+
+
+def _patch_async_client(monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport) -> None:
+    original = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+def _transport(*responses) -> httpx.MockTransport:
+    iterator = iter(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        try:
+            value = next(iterator)
+        except StopIteration as exc:
+            raise AssertionError("Reachability made more HTTP calls than expected") from exc
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    return httpx.MockTransport(handler)
+
+
+async def test_check_firecrawl_ok_on_2xx(env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_async_client(monkeypatch, _transport(httpx.Response(200, text='{"ok":true}')))
+    result = await reachability.check_firecrawl(get_settings())
+    assert result.ok is True
+    assert "200" in result.detail
+
+
+async def test_check_firecrawl_falls_through_to_root_on_404(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Self-hosted Firecrawl may not expose /v1/health; the prober tries the
+    fallback endpoints and reports the first 2xx."""
+
+    _patch_async_client(
+        monkeypatch,
+        _transport(
+            httpx.Response(404, text="not found"),
+            httpx.Response(404, text="not found"),
+            httpx.Response(200, text="root ok"),
+        ),
+    )
+    result = await reachability.check_firecrawl(get_settings())
+    assert result.ok is True
+
+
+async def test_check_firecrawl_reports_unreachable_on_network_error(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_async_client(
+        monkeypatch,
+        _transport(
+            httpx.ConnectError("connect refused"),
+            httpx.ConnectError("connect refused"),
+            httpx.ConnectError("connect refused"),
+        ),
+    )
+    result = await reachability.check_firecrawl(get_settings())
+    assert result.ok is False
+    assert "unreachable" in result.detail
+
+
+async def test_check_firecrawl_reports_last_failure_when_all_endpoints_5xx(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_async_client(
+        monkeypatch,
+        _transport(
+            httpx.Response(502, text="bad gateway 1"),
+            httpx.Response(502, text="bad gateway 2"),
+            httpx.Response(502, text="bad gateway 3"),
+        ),
+    )
+    result = await reachability.check_firecrawl(get_settings())
+    assert result.ok is False
+    assert "502" in result.detail
+
+
+async def test_run_all_raises_when_any_check_fails(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_async_client(
+        monkeypatch,
+        _transport(
+            httpx.ConnectError("nope"),
+            httpx.ConnectError("nope"),
+            httpx.ConnectError("nope"),
+        ),
+    )
+    with pytest.raises(reachability.ReachabilityError, match="firecrawl"):
+        await reachability.run_all(get_settings())
+
+
+async def test_run_all_returns_results_when_all_pass(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_async_client(monkeypatch, _transport(httpx.Response(200, text="ok")))
+    results = await reachability.run_all(get_settings())
+    assert all(r.ok for r in results)
+    assert {r.name for r in results} == {"firecrawl"}

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 from pathlib import Path
 
+import pytest
 from app.core import database
+from app.services import jobs
 
 
 async def test_crash_recovery_resets_processing(env: Path) -> None:
@@ -31,38 +32,73 @@ async def test_crash_recovery_resets_processing(env: Path) -> None:
     assert status == "queued"
 
 
-async def test_run_returns_quickly_when_shutdown_set_after_start(env: Path, monkeypatch) -> None:
-    """Smoke-test the worker run() loop: bootstrap + crash recovery + signal
-    install + a polling iteration, then a shutdown via the asyncio event."""
+async def test_pickup_runs_pipeline_against_a_queued_job(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end inside the worker: insert a queued job, stub the extractor,
+    call _process_one, observe the job reach status=done with stage=extract."""
+
+    from app.config import get_settings
+    from app.services import extraction
+    from app.worker import _process_one
+
+    database.run_migrations(env)
+
+    # Stub the extractor so the test doesn't reach the network.
+    async def _fake_extract(url, settings):
+        return extraction.ExtractionResult(
+            markdown="# Example\n\nbody " * 200,
+            metadata={"title": "Example article"},
+        )
+
+    monkeypatch.setattr(extraction, "extract", _fake_extract)
+
+    # Insert one queued job via the helper so episode_id is computed.
+    conn = database.connect(database.db_path(env))
+    try:
+        jobs.create_job(conn, "https://example.test/article")
+    finally:
+        conn.close()
+
+    processed = await _process_one(get_settings())
+    assert processed is True
+
+    conn = database.connect(database.db_path(env))
+    try:
+        row = conn.execute(
+            "SELECT status, stage, error FROM jobs WHERE url = ?",
+            ("https://example.test/article",),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["status"] == "done"
+    assert row["stage"] == "extract"
+    assert row["error"] is None
+
+
+async def test_pickup_returns_false_when_no_queued_jobs(env: Path) -> None:
+    from app.config import get_settings
+    from app.worker import _process_one
+
+    database.run_migrations(env)
+    assert await _process_one(get_settings()) is False
+
+
+async def test_run_exits_cleanly_when_reachability_passes_and_shutdown_set(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Smoke the worker run() loop end-to-end with reachability stubbed."""
 
     from app import worker
+    from app.services import reachability
 
-    # Speed up the poll so the test isn't sluggish.
-    monkeypatch.setattr(
-        "app.worker.get_settings",
-        lambda: _FastSettings(env),
-    )
+    async def _stub_run_all(_settings):
+        return [reachability.CheckResult(name="firecrawl", ok=True, detail="stub")]
 
-    # signal.add_signal_handler isn't allowed from non-main threads; pytest-asyncio
-    # runs us on the main thread, so this is fine on Linux.
+    monkeypatch.setattr(reachability, "run_all", _stub_run_all)
+
     task = asyncio.create_task(worker.run())
-    # Let bootstrap + crash recovery + signal install finish.
-    await asyncio.sleep(0.1)
-    # Cancel cleanly via signal-style shutdown: we can't send a real signal from
-    # inside a test reliably, so close the task. The worker checks shutdown
-    # between poll iterations.
+    await asyncio.sleep(0.2)
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await task
-    # Logger should have emitted the worker_starting banner.
-    assert logging.getLogger("app.worker") is not None
-
-
-class _FastSettings:
-    """Minimal stand-in so the worker loop polls quickly."""
-
-    def __init__(self, data_dir: Path) -> None:
-        self.DATA_DIR = data_dir
-        self.LOG_LEVEL = "INFO"
-        self.LOG_FORMAT = "text"
-        self.QUEUE_POLL_INTERVAL_SECONDS = 0.05

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "uvicorn[standard]>=0.32",
     "pydantic>=2.9",
     "pydantic-settings>=2.6",
+    "httpx>=0.27",
+    "tenacity>=9.0",
 ]
 
 # PEP 735 dependency groups: `uv sync --no-dev` excludes these in the runtime
@@ -20,7 +22,6 @@ dependencies = [
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
-    "httpx>=0.27",
     "ruff>=0.7",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -38,14 +38,15 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "tenacity" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -54,14 +55,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "tenacity", specifier = ">=9.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.7" },
@@ -417,6 +419,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds the extract stage of the pipeline plus the queue + API surface that drives it. `POST /api/v1/submit` enqueues a job, the worker picks it up via `claim_next_queued` (atomic SELECT+UPDATE under `BEGIN IMMEDIATE`), runs `services/extraction.py` with tenacity retries, and `GET /api/v1/status/{job_id}` reports stage transitions.
- Pipeline orchestrator: every stage writes its name to `jobs.stage` before work, structured logs emit `stage_start`/`stage_end`/`stage_failed` with `job_id`/`episode_id`/`stage` stamped via contextvars, whole job wrapped in `asyncio.wait_for(JOB_TIMEOUT_SECONDS)`. Shared `_finalize_failure` guards both `_last_stage` and `_persist_failure` so secondary DB errors can't mask the original.
- Submit endpoint validates with `AnyHttpUrl` but preserves the user's raw URL byte-for-byte so `episode_id` and the stored URL are stable. `extra="forbid"` makes typos like `{"reprcess": true}` surface as 400.
- Reachability prober tries `/v1/health`, `/health`, then `/` and accepts the first 2xx (build plan's "GET / or /health per Firecrawl version"). Worker `sys.exit(1)`s on failure; FastAPI lifespan deliberately does NOT call it so `/health/ready` stays reachable for triage.
- 59 tests total (43 new): extraction retry semantics, pipeline timeout + failure paths, API 201/400/409/200/404/500 envelope, reachability happy + fallback + failure, end-to-end worker pickup.

See `CHANGELOG.md` for the full multi-agent review findings list and the fixes applied (including atomic create_job race fix, BaseException-catching stage logger, jsonable_encoder validation handler, and the Firecrawl health endpoint fallback).

## Test plan

- [x] `uv run pytest` — 59/59 pass
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `docker build` succeeds with `--frozen` (no lockfile drift)
- [x] Container smoke with a mock Firecrawl: `POST /api/v1/submit` returns 201, status moves queued → done in single-digit ms, structured logs include `pipeline_start`, `stage_start`, `extract_complete`, `stage_end (duration_ms)`, `pipeline_done`
- [x] Typo'd field `{"reprcess": true}` returns 400 with `extra_forbidden` detail
- [x] `https://Example.test/Article?id=42` round-trips byte-identical through submit → status
- [x] Reachability picks `/v1/health` (the mock's responding endpoint) and logs `"HTTP 200 from /v1/health"`