### PR TITLE
Phase 7: RSS feed and media serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Added (Phase 7 - RSS Feed and Media Serving)
+
+- Pipeline now runs **extract -> cleanup -> corrections -> chunk -> tts -> audio -> artwork -> transcript -> finalize**. Final `status=done` with `stage=finalize`. The finalize stage upserts a row into the `episodes` table that the RSS feed and media handlers read from.
+- `backend/app/core/database.py`: migration `002_settings_kv` appends a `settings(key, value, updated_at)` k/v table for `podcast:guid` and future runtime knobs. Phase-1 schema is left untouched.
+- `backend/app/services/episodes.py`: typed `Episode` dataclass + `upsert`, `get_by_id`, `list_published` (newest-first, filters out rows with `audio_path IS NULL` so half-finalized jobs don't leak into the feed), `latest_updated_at` (for the RSS `Last-Modified` header and `<lastBuildDate>` field). `upsert` preserves `pub_date` on update (original publish moment) but bumps `updated_at` so clients see a fresh build.
+- `backend/app/services/settings_store.py`: k/v get/set + `get_or_init_podcast_guid` which derives a UUIDv5 from `BASE_URL` on first call and persists it. The PC2 spec requires the guid stay stable across feed-URL changes, so the persisted value is returned verbatim on subsequent calls regardless of `BASE_URL`.
+- `backend/app/services/feed.py`: `render(episodes, settings, podcast_guid, last_build) -> bytes`. feedgen renders Atom + iTunes namespaces; PC2 (`podcast:` namespace) tags are layered on via string-level XML construction afterwards (`podcast:guid`, `podcast:locked` with `owner=FEED_EMAIL`, `podcast:txt purpose="ai-content"` at channel level; `podcast:transcript` per item when `transcript_vtt` is present). Item enclosures get the on-disk MP3 size via `Path.stat().st_size` (missing files report length=0 rather than 500). `itunes:duration` renders as `HH:MM:SS`. Uses `defusedxml.ElementTree.fromstring` for parsing feedgen's output — XXE/billion-laughs defense-in-depth, even though the parser only ever sees our own output.
+- `backend/app/api/rss.py`: `GET /rss/rss.xml` -- streams the rendered feed with `Cache-Control: public, max-age=RSS_CACHE_MAX_AGE_SECONDS` and `Last-Modified` derived from the newest episode's `updated_at` (or the channel build time when the feed is empty). `If-Modified-Since` round-trips to `304 Not Modified` so podcast clients don't refetch the full body on every poll.
+- `backend/app/api/media.py`: `GET /media/{episode_id}.mp3`, `/media/{episode_id}.jpg` serve from disk via `FileResponse` with the right content-types and a 24h cache. `GET /media/{episode_id}.vtt` serves the transcript directly from the episode row's `transcript_vtt` column with `Cache-Control: public, max-age=86400`. The `episode_id` route parameter is validated against a strict allowlist (`^[A-Za-z0-9_-]+$`) so a client can't use `..` or absolute paths to escape `DATA_DIR/media`.
+- `backend/app/services/pipeline.py`: `_stage_finalize` calls `episodes.upsert` with the live audio/artwork/vtt/duration produced by prior stages. Title and author come from the extraction metadata; when Firecrawl doesn't report an author the row falls back to `FEED_AUTHOR` so the iTunes author field stays populated. The transcript stage no longer drops its VTT on the floor.
+- `backend/app/main.py`: mounted `rss` and `media` routers at the root prefix (the build-plan paths are `/rss/rss.xml` and `/media/{id}.{ext}`, not `/api/v1/*`).
+- Runtime deps: `feedgen>=1.0`, `defusedxml>=0.7` (plus transitive `lxml`, `python-dateutil`).
+
+Tests (43 new, 240 total)
+
+- `test_episodes.py` (5): insert + update by same id (pub_date preserved on update), list_published newest-first ordering, half-finalized rows excluded, get_by_id None for unknown, latest_updated_at tracks most-recent published.
+- `test_settings_store.py` (7): get/set round-trip, upsert on existing key, get_or_init persists first call, stable across calls, UUIDv5 of BASE_URL is reproducible, returns persisted value even when BASE_URL changes.
+- `test_feed.py` (13): channel title/description/language/image, PC2 guid/locked/txt tags, enclosure length from filesize (and 0 when missing), itunes:duration HH:MM:SS, podcast:transcript present when VTT, omitted when not, per-episode jpg vs feed-level artwork fallback, atom:link self pointing at /rss/rss.xml, `_hms` edge cases (zero, negative, hour rollover), `_parse_iso` Z-suffix and garbage handling.
+- `test_api_rss.py` (7): 200 with valid XML body, Cache-Control header, Last-Modified round-trips to 304, full body when client is older, podcast:guid persists across requests, empty channel for no episodes, half-finalized rows excluded.
+- `test_api_media.py` (9): mp3/jpg/vtt 200 with correct content-types, 404 on missing files / missing episode / null transcript, path-traversal blocked at the route boundary (`..%2f` URL-encoded), dot-prefixed ids rejected by the allowlist regex.
+- `test_pipeline.py` (2): finalize upserts the episode row with audio/artwork/vtt/duration from the in-memory pipeline state; FEED_AUTHOR fallback when extraction metadata has no author.
+
+### Code-review pass (multi-agent /simplify + /code-review for Phase 7)
+
+Findings surfaced and applied:
+
+- **Channel `<link>` was pointing at the feed URL, not BASE_URL**: feedgen's `link()` setter binds the channel `<link>` to the *last* href passed. The original code called `rel='alternate'` then `rel='self'`, so the rendered `<link>` carried `/rss/rss.xml`. Swapped the order so `rel='self'` runs first and the channel `<link>` correctly renders BASE_URL (the website).
+- **Stdlib ElementTree was emitting `ns0:` / `ns1:` prefixes after the round-trip**: only the `podcast` namespace was registered, so the re-serialized feed lost the `atom:` and `itunes:` prefixes. Apple Podcasts and Cast Feed Validator reject the auto-prefixed forms. Now registers `atom`, `itunes`, and `podcast` namespaces at module load (before any render).
+- **PC2 channel tags were appended after `<item>` elements**: `ET.SubElement(channel, ...)` appends, so `podcast:guid` / `podcast:locked` / `podcast:txt` ended up at the bottom of the channel after all items. Some PC2 validators warn. Switched to `channel.insert(idx_before_first_item, el)` and added a `_first_item_index` helper.
+- **`podcast:guid` was derived from `uuid.NAMESPACE_URL` instead of the PC2 namespace**: the PC2 spec mandates UUIDv5 over the namespace `ead4c236-bf58-58c6-a2c6-a6b28d128cb6` with the scheme stripped and trailing slash removed. The previous derivation produced a value no other PC2-aware tool would compute for the same feed, defeating cross-aggregator deduplication. Added `_canonical_feed_url` helper, switched to the spec-mandated namespace.
+- **`podcast:txt` text was the literal string `"true"`**: not a recognized sentinel for any PC2 purpose. PC2-aware clients (Fountain, Podverse) display the body verbatim, which read as broken. Replaced with a human-readable disclosure (`"This podcast contains AI-generated narration via TTS."`) while keeping `purpose="ai-content"` on the attribute.
+- **Missing `<itunes:type>episodic</itunes:type>`**: Apple Podcasts defaults to serial-style ordering without this tag, which is wrong for the news/article-narration use case. Added via `fg.podcast.itunes_type("episodic")`.
+- **Missing `<podcast:medium>podcast</podcast:medium>`**: PC2-aware aggregators use this to route the feed into the correct player section. Added at the top of the PC2 channel block.
+- **`<image>` was missing `<title>` and `<link>` subelements**: RSS 2.0 requires all three; validators reject otherwise. Now passes `title=` and `link=` to `fg.image`.
+- **`zip(items, episodes, strict=False)` could silently misalign transcripts**: if feedgen ever filters or reorders entries, the per-item `podcast:transcript` URLs would attach to wrong items without a test failure. Switched to `strict=True` so the failure surfaces loudly.
+- **Bare `assert row is not None` in `episodes.upsert`**: removed under `python -O`, would surface a confusing `TypeError` instead of a clear failure. Replaced with `if row is None: raise RuntimeError(...)`.
+- **Path-traversal test passed for the wrong reason**: the encoded `..%2f` URL caused Starlette's router (not the in-handler regex) to 404. Added `test_media_routes_reject_dot_prefixed_id` that asserts the lowercase `"not found"` body shape from the custom error handler, proving `_validate_episode_id` actually fired.
+- **Cleanup**: removed unused `now_utc()` helper, removed unused `response: Response` parameter from `rss.py:get_rss`, dropped redundant `int(seconds)` cast in `_hms`, inlined the `_PODCAST_GUID_NAMESPACE` alias.
+
+New tests added by the review pass (8 more, 245 total):
+
+- `test_feed.py`: PC2 channel tags precede items, `itunes:type=episodic` present, `<image>` has `<url>`+`<title>`+`<link>`, channel `<link>` points at BASE_URL not the feed URL, `podcast:medium=podcast` present, `podcast:txt` carries the human-readable disclosure.
+- `test_settings_store.py`: `podcast:guid` is UUIDv5 over the PC2 namespace with the URL canonicalized (scheme stripped, trailing slash removed); `_canonical_feed_url` round-trips three input shapes.
+- `test_api_media.py`: `_validate_episode_id` rejection produces the lowercase `"not found"` body (proves the in-handler regex defense actually fires, not just FastAPI's router).
+
+Container smoke (`tmp/phase7_smoke.sh`) verified inside the runtime image: feedgen + defusedxml + lxml load in the slim image; seeded a synthetic episode, fetched `/rss/rss.xml` (200, 1957 B, `application/rss+xml`), validated the PC2 namespace via `defusedxml.ElementTree`, confirmed `itunes:duration=00:02:05`, `podcast:guid` is a stable UUIDv5, `enclosure length=13` matches the seeded MP3 bytes, `/media/{id}.mp3` returns `audio/mpeg`, `/media/{id}.jpg` returns `image/jpeg`, `/media/{id}.vtt` returns `text/vtt` with `Cache-Control: max-age=86400`, and `If-Modified-Since` round-trips to `304 Not Modified`.
+
 ### Added (Phase 6 - Artwork + Transcripts)
 
 - Pipeline now runs **extract → cleanup → corrections → chunk → tts → audio → artwork → transcript**. Final `status=done` with `stage=transcript`. Phase 7 will append finalize (which inserts/updates the episodes row + writes the transcript to disk).

--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -1,0 +1,99 @@
+"""``GET /media/{episode_id}.{mp3,jpg,vtt}`` handlers.
+
+mp3 and jpg are served from disk via ``FileResponse``; vtt is rendered from
+the episode row's ``transcript_vtt`` column (no separate file on disk so
+operators don't have to back up two copies of the transcript).
+
+The episode_id pattern is constrained to the alphabet jobs.py generates so
+no caller can use ``..`` or absolute paths to escape the media directory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi.responses import FileResponse
+
+from app.config import Settings, get_settings
+from app.core import database
+from app.core.paths import media_dir
+from app.services import episodes
+
+router = APIRouter(prefix="/media", tags=["media"])
+
+# jobs.py generates episode_ids as short hex tokens. This pattern enforces
+# the contract at the route boundary so a malformed id 404s before any
+# filesystem lookup -- defence-in-depth against path traversal.
+_EPISODE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _validate_episode_id(episode_id: str) -> None:
+    if not _EPISODE_ID_RE.match(episode_id):
+        raise HTTPException(status_code=404, detail="not found")
+
+
+def _safe_path(root: Path, name: str) -> Path:
+    """Resolve and confirm the result still lives under ``root``."""
+
+    candidate = (root / name).resolve()
+    root_resolved = root.resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="not found") from exc
+    return candidate
+
+
+@router.get("/{episode_id}.mp3")
+async def get_mp3(
+    episode_id: str,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> FileResponse:
+    _validate_episode_id(episode_id)
+    path = _safe_path(media_dir(settings), f"{episode_id}.mp3")
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="not found")
+    return FileResponse(
+        path,
+        media_type="audio/mpeg",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@router.get("/{episode_id}.jpg")
+async def get_jpg(
+    episode_id: str,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> FileResponse:
+    _validate_episode_id(episode_id)
+    path = _safe_path(media_dir(settings), f"{episode_id}.jpg")
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="not found")
+    return FileResponse(
+        path,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@router.get("/{episode_id}.vtt")
+async def get_vtt(
+    episode_id: str,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> Response:
+    _validate_episode_id(episode_id)
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        episode = episodes.get_by_id(conn, episode_id)
+    finally:
+        conn.close()
+    if episode is None or not episode.transcript_vtt:
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(
+        content=episode.transcript_vtt,
+        media_type="text/vtt; charset=utf-8",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )

--- a/backend/app/api/rss.py
+++ b/backend/app/api/rss.py
@@ -1,0 +1,81 @@
+"""``GET /rss/rss.xml`` -- the Podcasting 2.0 RSS feed.
+
+Channel metadata comes from ``Settings``; episodes come from the
+``episodes`` table; ``podcast:guid`` is initialized once and persisted via
+``services.settings_store``.
+
+HTTP caching: ``Last-Modified`` is set from the newest episode's
+``updated_at`` (or the channel build time if there are no episodes), and
+``If-Modified-Since`` round-trips to a ``304 Not Modified`` so podcast
+clients don't refetch the full body on every poll.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from email.utils import format_datetime, parsedate_to_datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, Response
+
+from app.config import Settings, get_settings
+from app.core import database
+from app.services import episodes, feed, settings_store
+
+router = APIRouter(prefix="/rss", tags=["rss"])
+
+
+@router.get("/rss.xml")
+async def get_rss(
+    settings: Annotated[Settings, Depends(get_settings)],
+    if_modified_since: Annotated[str | None, Header()] = None,
+) -> Response:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        rows = episodes.list_published(conn)
+        latest = episodes.latest_updated_at(conn)
+        guid = settings_store.get_or_init_podcast_guid(conn, settings.BASE_URL)
+    finally:
+        conn.close()
+
+    last_build = _last_build_datetime(latest)
+    not_modified = _is_not_modified(if_modified_since, last_build)
+    headers = {
+        "Last-Modified": format_datetime(last_build, usegmt=True),
+        "Cache-Control": f"public, max-age={settings.RSS_CACHE_MAX_AGE_SECONDS}",
+    }
+    if not_modified:
+        return Response(status_code=304, headers=headers)
+
+    body = feed.render(
+        rows,
+        settings=settings,
+        podcast_guid=guid,
+        last_build=last_build,
+    )
+    return Response(
+        content=body,
+        media_type="application/rss+xml; charset=utf-8",
+        headers=headers,
+    )
+
+
+def _last_build_datetime(latest: str | None) -> datetime:
+    if latest is None:
+        return datetime.now(UTC).replace(microsecond=0)
+    parsed = feed._parse_iso(latest)
+    return parsed.astimezone(UTC) if parsed else datetime.now(UTC).replace(microsecond=0)
+
+
+def _is_not_modified(if_modified_since: str | None, last_build: datetime) -> bool:
+    if not if_modified_since:
+        return False
+    try:
+        client_time = parsedate_to_datetime(if_modified_since)
+    except (TypeError, ValueError):
+        return False
+    if client_time.tzinfo is None:
+        client_time = client_time.replace(tzinfo=UTC)
+    # HTTP-date precision is one second; >= comparison so a client with the
+    # exact build time gets 304 rather than a redundant full body.
+    return client_time >= last_build.replace(microsecond=0)

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -161,8 +161,23 @@ def _m001_initial_schema(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_episodes_pub_date ON episodes(pub_date DESC)")
 
 
+def _m002_settings_kv(conn: sqlite3.Connection) -> None:
+    """Phase 7: settings key/value store (podcast:guid, future runtime knobs)."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS settings (
+            key         TEXT PRIMARY KEY,
+            value       TEXT NOT NULL,
+            updated_at  TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        )
+        """
+    )
+
+
 MIGRATIONS: list[tuple[str, Migration]] = [
     ("001_initial_schema", _m001_initial_schema),
+    ("002_settings_kv", _m002_settings_kv),
 ]
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,8 @@ from fastapi import FastAPI
 
 from app.api import errors as error_handlers
 from app.api.health import router as health_router
+from app.api.media import router as media_router
+from app.api.rss import router as rss_router
 from app.api.v1.router import router as v1_router
 from app.config import get_settings
 from app.startup import bootstrap
@@ -36,6 +38,8 @@ def create_app() -> FastAPI:
     )
     app.include_router(health_router)
     app.include_router(v1_router)
+    app.include_router(rss_router)
+    app.include_router(media_router)
     error_handlers.register(app)
     return app
 

--- a/backend/app/services/episodes.py
+++ b/backend/app/services/episodes.py
@@ -1,0 +1,149 @@
+"""CRUD helpers for the ``episodes`` table.
+
+The pipeline's finalize stage upserts a row here; the RSS render and the
+media handlers read from it. ``original_url`` is the natural deduplication
+key so re-running a job for the same URL updates the existing row rather
+than producing a second feed entry.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Episode:
+    id: str
+    job_id: str | None
+    title: str | None
+    author: str | None
+    original_url: str
+    audio_path: str | None
+    artwork_path: str | None
+    transcript_vtt: str | None
+    duration_secs: int | None
+    pub_date: str
+    created_at: str
+    updated_at: str
+
+
+_SELECT_COLUMNS = (
+    "id, job_id, title, author, original_url, audio_path, artwork_path, "
+    "transcript_vtt, duration_secs, pub_date, created_at, updated_at"
+)
+
+
+def _row_to_episode(row: sqlite3.Row) -> Episode:
+    return Episode(
+        id=row["id"],
+        job_id=row["job_id"],
+        title=row["title"],
+        author=row["author"],
+        original_url=row["original_url"],
+        audio_path=row["audio_path"],
+        artwork_path=row["artwork_path"],
+        transcript_vtt=row["transcript_vtt"],
+        duration_secs=row["duration_secs"],
+        pub_date=row["pub_date"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def upsert(
+    conn: sqlite3.Connection,
+    *,
+    id: str,
+    job_id: str | None,
+    original_url: str,
+    title: str | None,
+    author: str | None,
+    audio_path: str | None,
+    artwork_path: str | None,
+    transcript_vtt: str | None,
+    duration_secs: int | None,
+) -> Episode:
+    """Insert a new episode row, or update the existing one keyed by id.
+
+    On update, ``pub_date`` is preserved (the original publish moment) but
+    ``updated_at`` is bumped to now so RSS clients see a fresh ``lastBuildDate``.
+    """
+
+    conn.execute(
+        """
+        INSERT INTO episodes (
+            id, job_id, title, author, original_url, audio_path,
+            artwork_path, transcript_vtt, duration_secs
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            job_id          = excluded.job_id,
+            title           = excluded.title,
+            author          = excluded.author,
+            original_url    = excluded.original_url,
+            audio_path      = excluded.audio_path,
+            artwork_path    = excluded.artwork_path,
+            transcript_vtt  = excluded.transcript_vtt,
+            duration_secs   = excluded.duration_secs,
+            updated_at      = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+        """,
+        (
+            id,
+            job_id,
+            title,
+            author,
+            original_url,
+            audio_path,
+            artwork_path,
+            transcript_vtt,
+            duration_secs,
+        ),
+    )
+    conn.commit()
+    row = conn.execute(f"SELECT {_SELECT_COLUMNS} FROM episodes WHERE id = ?", (id,)).fetchone()
+    if row is None:
+        # ``assert`` would disappear under ``python -O``; a real check stays.
+        raise RuntimeError(f"episode {id!r} disappeared between upsert and SELECT")
+    return _row_to_episode(row)
+
+
+def get_by_id(conn: sqlite3.Connection, episode_id: str) -> Episode | None:
+    row = conn.execute(
+        f"SELECT {_SELECT_COLUMNS} FROM episodes WHERE id = ?", (episode_id,)
+    ).fetchone()
+    return None if row is None else _row_to_episode(row)
+
+
+def list_published(conn: sqlite3.Connection) -> list[Episode]:
+    """Return episodes in newest-first order for RSS rendering.
+
+    Filters to rows that have a non-NULL ``audio_path`` so a half-finalized
+    row (audio still pending) doesn't leak into the feed.
+    """
+
+    rows = conn.execute(
+        f"""
+        SELECT {_SELECT_COLUMNS}
+        FROM episodes
+        WHERE audio_path IS NOT NULL
+        ORDER BY pub_date DESC, created_at DESC
+        """
+    ).fetchall()
+    return [_row_to_episode(row) for row in rows]
+
+
+def latest_updated_at(conn: sqlite3.Connection) -> str | None:
+    """Most-recent ``updated_at`` across published episodes, for the RSS
+    ``Last-Modified`` header and the ``<lastBuildDate>`` channel field."""
+
+    row = conn.execute(
+        """
+        SELECT updated_at
+        FROM episodes
+        WHERE audio_path IS NOT NULL
+        ORDER BY updated_at DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    return None if row is None else row["updated_at"]

--- a/backend/app/services/feed.py
+++ b/backend/app/services/feed.py
@@ -1,0 +1,257 @@
+"""RSS feed generation per build-plan.md Phase 7.
+
+feedgen renders the Atom + iTunes namespaces; the Podcasting 2.0 (``podcast:``)
+namespace is layered on via string-level XML construction afterwards because
+feedgen doesn't model it natively. That follows the MinusPod precedent.
+
+Channel fields come from ``Settings`` (operator env vars); per-episode fields
+come from the ``episodes`` table. ``podcast:guid`` is persisted via
+``settings_store.get_or_init_podcast_guid`` so the identifier is stable across
+restarts and feed-URL changes.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import defusedxml.ElementTree as DET
+from feedgen.feed import FeedGenerator
+
+from app.config import Settings
+from app.services.episodes import Episode
+
+logger = logging.getLogger("app.services.feed")
+
+_PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+_ITUNES_NS = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+
+# Register the namespace prefixes ONCE at module load so the round-trip
+# through ET.tostring re-emits ``podcast:`` / ``itunes:`` / ``atom:`` instead
+# of stdlib ElementTree's auto-assigned ``ns0:`` / ``ns1:`` prefixes. Apple
+# Podcasts and Cast Feed Validator reject the auto-prefixed forms.
+ET.register_namespace("podcast", _PODCAST_NS)
+ET.register_namespace("itunes", _ITUNES_NS)
+ET.register_namespace("atom", _ATOM_NS)
+
+
+def render(
+    episodes: list[Episode],
+    *,
+    settings: Settings,
+    podcast_guid: str,
+    last_build: datetime,
+) -> bytes:
+    """Render the full RSS document (channel + items + PC2 tags) as bytes.
+
+    ``last_build`` is the timestamp the operator wants to advertise as
+    ``<lastBuildDate>``; the caller derives it from the newest episode's
+    ``updated_at`` (and falls back to ``now``).
+    """
+
+    fg = FeedGenerator()
+    fg.load_extension("podcast")  # iTunes namespace shortcut
+
+    fg.title(settings.FEED_TITLE)
+    fg.description(settings.FEED_DESCRIPTION)
+    fg.author({"name": settings.FEED_AUTHOR, "email": settings.FEED_EMAIL})
+    fg.language(settings.FEED_LANGUAGE)
+    # Order matters: feedgen's channel ``<link>`` is bound to the LAST link()
+    # call. Call the atom ``rel="self"`` first so the channel ``<link>``
+    # element ends up pointing at BASE_URL (the website) rather than at the
+    # feed URL itself, which is the conventional rendering for podcast
+    # players.
+    fg.link(href=f"{settings.BASE_URL.rstrip('/')}/rss/rss.xml", rel="self")
+    fg.link(href=settings.BASE_URL, rel="alternate")
+    # Legacy ``<image>`` needs ``<title>`` and ``<link>`` per RSS 2.0 to
+    # validate; the build plan calls these out explicitly.
+    fg.image(
+        url=settings.FEED_ARTWORK_URL,
+        title=settings.FEED_TITLE,
+        link=settings.BASE_URL,
+    )
+    fg.lastBuildDate(last_build)
+    fg.podcast.itunes_author(settings.FEED_AUTHOR)
+    fg.podcast.itunes_owner(name=settings.FEED_AUTHOR, email=settings.FEED_EMAIL)
+    fg.podcast.itunes_category(settings.FEED_CATEGORY)
+    fg.podcast.itunes_image(settings.FEED_ARTWORK_URL)
+    fg.podcast.itunes_explicit("yes" if settings.FEED_EXPLICIT else "no")
+    fg.podcast.itunes_summary(settings.FEED_DESCRIPTION)
+    # Tell Apple Podcasts this is an episodic (not serial) feed so the UI
+    # displays newest-first.
+    fg.podcast.itunes_type("episodic")
+
+    if episodes:
+        # pubDate of the channel mirrors the newest episode per the build plan.
+        newest_pub = _parse_iso(episodes[0].pub_date)
+        if newest_pub is not None:
+            fg.pubDate(newest_pub)
+
+    for ep in episodes:
+        item = fg.add_entry(order="append")
+        item.id(ep.id)
+        item.guid(ep.id, permalink=False)
+        if ep.title:
+            item.title(ep.title)
+        if ep.author:
+            item.author({"name": ep.author})
+        item.link(href=ep.original_url)
+        item.description(ep.title or ep.original_url)
+        item.pubDate(_parse_iso(ep.pub_date) or last_build)
+        if ep.audio_path:
+            audio_url = _media_url(settings.BASE_URL, ep.id, "mp3")
+            item.enclosure(
+                url=audio_url,
+                length=str(_safe_filesize(ep.audio_path)),
+                type="audio/mpeg",
+            )
+        if ep.duration_secs is not None:
+            item.podcast.itunes_duration(_hms(ep.duration_secs))
+        item.podcast.itunes_image(
+            _media_url(settings.BASE_URL, ep.id, "jpg")
+            if ep.artwork_path
+            else settings.FEED_ARTWORK_URL
+        )
+        item.podcast.itunes_explicit("yes" if settings.FEED_EXPLICIT else "no")
+
+    base_xml = fg.rss_str(pretty=False)
+    return _inject_pc2_tags(
+        base_xml,
+        podcast_guid=podcast_guid,
+        episodes=episodes,
+        settings=settings,
+    )
+
+
+def _inject_pc2_tags(
+    xml_bytes: bytes,
+    *,
+    podcast_guid: str,
+    episodes: list[Episode],
+    settings: Settings,
+) -> bytes:
+    """Append the PC2 namespace + channel-level + per-item PC2 elements.
+
+    feedgen doesn't natively understand the ``podcast:`` namespace, so we
+    re-parse the rendered RSS, register the namespace on the ``<rss>`` root,
+    add channel-level PC2 tags (``guid``, ``txt purpose="ai-content"``,
+    ``locked``), and a per-item ``podcast:transcript`` element pointing at
+    the VTT handler.
+    """
+
+    # ``defusedxml.ElementTree.fromstring`` blocks XXE / billion-laughs / DTD
+    # retrieval; the stdlib parser would happily expand them. feedgen's own
+    # output never contains attacker input (we control every channel/item
+    # field), but defense-in-depth is cheap.
+    root = DET.fromstring(xml_bytes)
+    channel = root.find("channel")
+    if channel is None:
+        return xml_bytes  # unreachable but keeps the type-checker happy
+
+    # PC2 channel-level tags must precede ``<item>`` elements per the
+    # Podcast Index reference feeds; some validators warn otherwise. Build
+    # the tags up front, then ``insert`` them before the first item.
+    insert_at = _first_item_index(channel)
+
+    pc2_medium = ET.Element(f"{{{_PODCAST_NS}}}medium")
+    pc2_medium.text = "podcast"
+    channel.insert(insert_at, pc2_medium)
+    insert_at += 1
+
+    pc2_guid = ET.Element(f"{{{_PODCAST_NS}}}guid")
+    pc2_guid.text = podcast_guid
+    channel.insert(insert_at, pc2_guid)
+    insert_at += 1
+
+    pc2_locked = ET.Element(f"{{{_PODCAST_NS}}}locked")
+    pc2_locked.text = "yes"
+    pc2_locked.set("owner", settings.FEED_EMAIL)
+    channel.insert(insert_at, pc2_locked)
+    insert_at += 1
+
+    # ``podcast:txt`` is free-form text gated by the ``purpose`` attribute.
+    # Carry a human-readable disclosure so PC2-aware clients (Fountain,
+    # Podverse) can surface the AI-content flag without parsing a sentinel.
+    pc2_txt = ET.Element(f"{{{_PODCAST_NS}}}txt")
+    pc2_txt.text = "This podcast contains AI-generated narration via TTS."
+    pc2_txt.set("purpose", "ai-content")
+    channel.insert(insert_at, pc2_txt)
+
+    items = channel.findall("item")
+    # ``strict=True`` makes the assertion ``items align with episodes`` a
+    # hard contract: if a future feedgen change drops or reorders entries
+    # the build fails loudly rather than silently shipping wrong-episode
+    # transcripts.
+    for item_el, ep in zip(items, episodes, strict=True):
+        if not ep.transcript_vtt:
+            continue
+        transcript_url = _media_url(settings.BASE_URL, ep.id, "vtt")
+        ET.SubElement(
+            item_el,
+            f"{{{_PODCAST_NS}}}transcript",
+            attrib={
+                "url": transcript_url,
+                "type": "text/vtt",
+                "language": settings.FEED_LANGUAGE,
+                "rel": "captions",
+            },
+        )
+
+    # ``xml_declaration=True`` matches feedgen's default rss_str() output so
+    # the response body has the same prolog clients are used to.
+    return ET.tostring(root, encoding="UTF-8", xml_declaration=True)
+
+
+def _first_item_index(channel: ET.Element) -> int:
+    """Index of the first ``<item>`` child, or len(channel) if there are
+    none -- where PC2 channel-level tags should be inserted."""
+
+    for index, child in enumerate(channel):
+        if child.tag == "item":
+            return index
+    return len(channel)
+
+
+def _media_url(base_url: str, episode_id: str, ext: str) -> str:
+    return f"{base_url.rstrip('/')}/media/{episode_id}.{ext}"
+
+
+def _hms(seconds: int) -> str:
+    """Render integer seconds as ``HH:MM:SS`` per itunes:duration spec."""
+
+    secs = max(0, seconds)
+    hours, remainder = divmod(secs, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def _parse_iso(value: str) -> datetime | None:
+    """Parse the ISO-8601 timestamps SQLite emits via ``strftime``.
+
+    feedgen requires tz-aware datetimes; the DB values end in ``Z`` so we
+    swap that for ``+00:00`` to satisfy ``datetime.fromisoformat`` on
+    Python < 3.11 hosts. On 3.11+ the literal ``Z`` parses but the swap is
+    harmless.
+    """
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        logger.warning(
+            "Could not parse episode timestamp",
+            extra={"event": "feed_timestamp_parse_failed", "value": value},
+        )
+        return None
+
+
+def _safe_filesize(path_str: str) -> int:
+    """Best-effort enclosure length. Missing files report 0 so the feed
+    still validates rather than 500-ing on a stale row."""
+
+    try:
+        return Path(path_str).stat().st_size
+    except OSError:
+        return 0

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -1,8 +1,9 @@
 """Job processing pipeline orchestrator.
 
-Phase 6 wires the full read-aloud chain: extract -> cleanup -> corrections
--> chunk -> tts -> audio -> artwork -> transcript. Phase 7 appends finalize
-which inserts/updates the episodes row.
+Phase 7 wires the full chain: extract -> cleanup -> corrections -> chunk ->
+tts -> audio -> artwork -> transcript -> finalize. Finalize upserts the
+``episodes`` row that the RSS feed and ``/media/{id}.{mp3,jpg,vtt}``
+handlers serve.
 
 Conventions enforced here:
 - Every stage writes its name to ``jobs.stage`` BEFORE doing any work, so the
@@ -31,6 +32,7 @@ from app.services import (
     audio,
     chunker,
     corrections,
+    episodes,
     extraction,
     jobs,
     llm,
@@ -187,13 +189,13 @@ async def _run_stages(job: jobs.Job, settings: Settings) -> None:
         job.id,
         settings,
     )
-    await _run_stage(
+    audio_result = await _run_stage(
         "audio",
         lambda: _stage_audio(job, chunk_results, settings),
         job.id,
         settings,
     )
-    await _run_stage(
+    artwork_result = await _run_stage(
         "artwork",
         lambda: _stage_artwork(job, extraction_result.metadata, settings),
         job.id,
@@ -205,10 +207,20 @@ async def _run_stages(job: jobs.Job, settings: Settings) -> None:
         job.id,
         settings,
     )
-    # vtt content lives in memory; Phase 7's finalize stage writes it to
-    # episodes.transcript_vtt alongside audio_path + artwork_path.
-    _ = vtt
-    _mark_done(job.id, final_stage="transcript", settings=settings)
+    await _run_stage(
+        "finalize",
+        lambda: _stage_finalize(
+            job,
+            metadata=extraction_result.metadata,
+            audio_result=audio_result,
+            artwork_result=artwork_result,
+            vtt=vtt,
+            settings=settings,
+        ),
+        job.id,
+        settings,
+    )
+    _mark_done(job.id, final_stage="finalize", settings=settings)
 
 
 async def _run_stage(
@@ -435,6 +447,65 @@ async def _stage_transcript(
         },
     )
     return vtt
+
+
+async def _stage_finalize(
+    job: jobs.Job,
+    *,
+    metadata: dict[str, Any],
+    audio_result: audio.EncodeResult,
+    artwork_result: artwork.ArtworkResult | None,
+    vtt: str,
+    settings: Settings,
+) -> None:
+    """Upsert the ``episodes`` row that the RSS feed and media handlers read.
+
+    Title and author come from the extraction metadata (Firecrawl populates
+    both when the article has them); ``original_url`` is the job's input
+    URL; durations come from the audio stage; ``transcript_vtt`` is the
+    in-memory VTT rendered in the prior stage.
+    """
+
+    title = _coerce_str(metadata.get("title"))
+    author = _coerce_str(metadata.get("author")) or settings.FEED_AUTHOR
+    artwork_path = str(artwork_result.jpg_path) if artwork_result else None
+    duration_secs = round(audio_result.duration_secs)
+
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        episodes.upsert(
+            conn,
+            id=job.episode_id,
+            job_id=job.id,
+            original_url=job.url,
+            title=title,
+            author=author,
+            audio_path=str(audio_result.mp3_path),
+            artwork_path=artwork_path,
+            transcript_vtt=vtt,
+            duration_secs=duration_secs,
+        )
+    finally:
+        conn.close()
+
+    logger.info(
+        "Episode finalized",
+        extra={
+            "event": "finalize_complete",
+            "episode_id": job.episode_id,
+            "title": title,
+            "duration_secs": duration_secs,
+            "has_artwork": artwork_path is not None,
+            "vtt_bytes": len(vtt.encode("utf-8")),
+        },
+    )
+
+
+def _coerce_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
 
 
 async def _stage_corrections(cleaned: str, settings: Settings) -> str:

--- a/backend/app/services/settings_store.py
+++ b/backend/app/services/settings_store.py
@@ -1,0 +1,73 @@
+"""Key/value settings store backed by the SQLite ``settings`` table.
+
+Phase 7 uses this for ``podcast:guid`` (stable feed identifier per the
+Podcasting 2.0 spec). Subsequent phases will pile on runtime knobs
+(retention overrides, auth tunables, etc).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from urllib.parse import urlsplit
+
+# The Podcasting 2.0 ``podcast:guid`` spec
+# (https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#guid)
+# requires UUIDv5 derived from the feed URL with the scheme stripped and
+# trailing slash removed, using this specific namespace. Using
+# ``uuid.NAMESPACE_URL`` would produce a value that no other PC2-aware
+# tool computes for the same feed URL, defeating the spec's cross-aggregator
+# deduplication.
+_PODCAST_GUID_NAMESPACE = uuid.UUID("ead4c236-bf58-58c6-a2c6-a6b28d128cb6")
+PODCAST_GUID_KEY = "podcast_guid"
+
+
+def get(conn: sqlite3.Connection, key: str) -> str | None:
+    row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    return None if row is None else row["value"]
+
+
+def set_(conn: sqlite3.Connection, key: str, value: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO settings (key, value, updated_at)
+        VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at
+        """,
+        (key, value),
+    )
+    conn.commit()
+
+
+def get_or_init_podcast_guid(conn: sqlite3.Connection, base_url: str) -> str:
+    """Return the stable ``podcast:guid``, initializing on first call.
+
+    First call derives a UUIDv5 from ``BASE_URL`` and persists it; subsequent
+    calls return the persisted value verbatim. Per the Podcasting 2.0 spec
+    the GUID must remain stable even if the feed URL or hosting provider
+    changes, so storing it (rather than recomputing every render) is the
+    correct shape.
+    """
+
+    existing = get(conn, PODCAST_GUID_KEY)
+    if existing:
+        return existing
+    fresh = str(uuid.uuid5(_PODCAST_GUID_NAMESPACE, _canonical_feed_url(base_url)))
+    set_(conn, PODCAST_GUID_KEY, fresh)
+    return fresh
+
+
+def _canonical_feed_url(base_url: str) -> str:
+    """Strip scheme and trailing slash per the PC2 guid derivation rule.
+
+    ``https://example.com/`` -> ``example.com``;
+    ``http://example.com/path/`` -> ``example.com/path``.
+    """
+
+    parts = urlsplit(base_url)
+    host = parts.netloc or parts.path  # tolerate inputs lacking scheme
+    path = parts.path if parts.netloc else ""
+    canonical = (host + path).rstrip("/")
+    return canonical

--- a/backend/tests/test_api_media.py
+++ b/backend/tests/test_api_media.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core import database
+from app.core.paths import media_dir
+from app.main import create_app
+from app.services import episodes
+from fastapi.testclient import TestClient
+
+
+def _client(env: Path) -> TestClient:
+    database.run_migrations(env)
+    return TestClient(create_app())
+
+
+def _seed_episode(env: Path, *, id_: str, transcript_vtt: str | None) -> Path:
+    database.run_migrations(env)
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id=id_,
+            job_id=None,
+            original_url="https://example.test/a",
+            title="An Article",
+            author="Author",
+            audio_path=f"/data/media/{id_}.mp3",
+            artwork_path=f"/data/media/{id_}.jpg",
+            transcript_vtt=transcript_vtt,
+            duration_secs=10,
+        )
+    finally:
+        conn.close()
+    from app.config import get_settings
+
+    return media_dir(get_settings())
+
+
+def test_get_mp3_serves_disk_file_with_audio_content_type(env: Path) -> None:
+    media = _seed_episode(env, id_="abc", transcript_vtt="WEBVTT\n")
+    media.mkdir(parents=True, exist_ok=True)
+    (media / "abc.mp3").write_bytes(b"FAKE_MP3")
+    with _client(env) as client:
+        response = client.get("/media/abc.mp3")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/mpeg"
+    assert response.content == b"FAKE_MP3"
+
+
+def test_get_jpg_serves_disk_file_with_image_content_type(env: Path) -> None:
+    media = _seed_episode(env, id_="abc", transcript_vtt=None)
+    media.mkdir(parents=True, exist_ok=True)
+    (media / "abc.jpg").write_bytes(b"FAKE_JPG")
+    with _client(env) as client:
+        response = client.get("/media/abc.jpg")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    assert response.content == b"FAKE_JPG"
+
+
+def test_get_vtt_serves_transcript_from_db_with_cache_header(env: Path) -> None:
+    _seed_episode(env, id_="abc", transcript_vtt="WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nhi\n")
+    with _client(env) as client:
+        response = client.get("/media/abc.vtt")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/vtt")
+    assert "max-age=86400" in response.headers["cache-control"]
+    assert response.text.startswith("WEBVTT")
+
+
+def test_get_mp3_returns_404_when_file_missing(env: Path) -> None:
+    _seed_episode(env, id_="abc", transcript_vtt=None)
+    with _client(env) as client:
+        response = client.get("/media/abc.mp3")
+    assert response.status_code == 404
+
+
+def test_get_jpg_returns_404_when_file_missing(env: Path) -> None:
+    _seed_episode(env, id_="abc", transcript_vtt=None)
+    with _client(env) as client:
+        response = client.get("/media/abc.jpg")
+    assert response.status_code == 404
+
+
+def test_get_vtt_returns_404_when_episode_missing(env: Path) -> None:
+    with _client(env) as client:
+        response = client.get("/media/unknown.vtt")
+    assert response.status_code == 404
+
+
+def test_get_vtt_returns_404_when_transcript_null(env: Path) -> None:
+    _seed_episode(env, id_="abc", transcript_vtt=None)
+    with _client(env) as client:
+        response = client.get("/media/abc.vtt")
+    assert response.status_code == 404
+
+
+def test_media_routes_reject_path_traversal(env: Path) -> None:
+    """The episode_id regex blocks `..` so a client can't escape media_dir."""
+
+    with _client(env) as client:
+        response = client.get("/media/..%2f..%2fetc%2fpasswd.mp3")
+    # FastAPI URL-decodes the path, so the literal `..` reaches the route and
+    # the regex check returns 404 (not 200, not 500).
+    assert response.status_code == 404
+
+
+def test_media_routes_reject_dot_prefixed_id(env: Path) -> None:
+    """An id that DOES match the route pattern but contains characters
+    outside ``[A-Za-z0-9_-]`` must be rejected by the in-handler regex.
+    The lowercase ``not found`` body proves ``_validate_episode_id`` fired
+    rather than Starlette's router 404'ing on a non-matching path."""
+
+    with _client(env) as client:
+        response = client.get("/media/.hidden.mp3")
+    assert response.status_code == 404
+    # The app's custom error handler renders ``{"error": <detail>, "status":
+    # <code>}`` (lowercase "not found"); Starlette's default router 404
+    # would produce ``"Not Found"`` (capital N), so the lowercase body
+    # proves ``_validate_episode_id`` is what rejected the request.
+    assert response.json() == {"error": "not found", "status": 404}

--- a/backend/tests/test_api_rss.py
+++ b/backend/tests/test_api_rss.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from email.utils import format_datetime, parsedate_to_datetime
+from pathlib import Path
+
+import defusedxml.ElementTree as DET
+from app.core import database
+from app.main import create_app
+from app.services import episodes
+from fastapi.testclient import TestClient
+
+_PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+
+
+def _client(env: Path) -> TestClient:
+    database.run_migrations(env)
+    return TestClient(create_app())
+
+
+def _seed(env: Path, *, audio_path: str = "/data/media/ep.mp3") -> None:
+    database.run_migrations(env)
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id="ep",
+            job_id=None,
+            original_url="https://example.test/a",
+            title="An Article",
+            author="Author Name",
+            audio_path=audio_path,
+            artwork_path=None,
+            transcript_vtt="WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nhi\n",
+            duration_secs=42,
+        )
+        conn.execute(
+            "UPDATE episodes SET pub_date='2026-05-28T18:00:00Z', "
+            "updated_at='2026-05-28T18:00:00Z' WHERE id='ep'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_get_rss_returns_200_with_xml_body(env: Path) -> None:
+    _seed(env)
+    with _client(env) as client:
+        response = client.get("/rss/rss.xml")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/rss+xml")
+    root = DET.fromstring(response.content)
+    assert root.tag == "rss"
+    items = root.findall("channel/item")
+    assert len(items) == 1
+
+
+def test_get_rss_emits_cache_control_header(env: Path) -> None:
+    _seed(env)
+    with _client(env) as client:
+        response = client.get("/rss/rss.xml")
+    cc = response.headers["cache-control"]
+    assert "public" in cc
+    assert "max-age=" in cc
+
+
+def test_get_rss_last_modified_round_trips_to_304(env: Path) -> None:
+    _seed(env)
+    with _client(env) as client:
+        first = client.get("/rss/rss.xml")
+        last_modified = first.headers["last-modified"]
+        # Reuse the Last-Modified value as If-Modified-Since; expect 304.
+        not_modified = client.get(
+            "/rss/rss.xml",
+            headers={"If-Modified-Since": last_modified},
+        )
+    assert first.status_code == 200
+    assert not_modified.status_code == 304
+    assert not_modified.headers["last-modified"] == last_modified
+    assert not_modified.content == b""
+
+
+def test_get_rss_returns_full_body_when_client_is_older(env: Path) -> None:
+    _seed(env)
+    with _client(env) as client:
+        old = format_datetime(parsedate_to_datetime("Sun, 01 Jan 2000 00:00:00 GMT"), usegmt=True)
+        response = client.get("/rss/rss.xml", headers={"If-Modified-Since": old})
+    assert response.status_code == 200
+    assert len(response.content) > 0
+
+
+def test_get_rss_persists_podcast_guid_across_requests(env: Path) -> None:
+    _seed(env)
+    with _client(env) as client:
+        first = client.get("/rss/rss.xml")
+        second = client.get("/rss/rss.xml")
+    g1 = DET.fromstring(first.content).find(f"channel/{{{_PODCAST_NS}}}guid").text
+    g2 = DET.fromstring(second.content).find(f"channel/{{{_PODCAST_NS}}}guid").text
+    assert g1 == g2
+
+
+def test_get_rss_with_no_episodes_returns_200_empty_channel(env: Path) -> None:
+    with _client(env) as client:
+        response = client.get("/rss/rss.xml")
+    assert response.status_code == 200
+    root = DET.fromstring(response.content)
+    assert len(root.findall("channel/item")) == 0
+
+
+def test_get_rss_excludes_episodes_with_null_audio(env: Path) -> None:
+    _seed(env, audio_path="/data/media/ep.mp3")
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id="half",
+            job_id=None,
+            original_url="https://example.test/half",
+            title="Half-baked",
+            author="A",
+            audio_path=None,
+            artwork_path=None,
+            transcript_vtt=None,
+            duration_secs=None,
+        )
+    finally:
+        conn.close()
+    with _client(env) as client:
+        response = client.get("/rss/rss.xml")
+    root = DET.fromstring(response.content)
+    guids = [g.text for g in root.findall("channel/item/guid")]
+    assert guids == ["ep"]

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -10,7 +10,7 @@ from app.core import database
 
 def test_run_migrations_creates_tables(tmp_path: Path) -> None:
     applied = database.run_migrations(tmp_path)
-    assert applied == ["001_initial_schema"]
+    assert applied == ["001_initial_schema", "002_settings_kv"]
 
     conn = database.connect(database.db_path(tmp_path))
     try:
@@ -25,7 +25,7 @@ def test_run_migrations_creates_tables(tmp_path: Path) -> None:
 def test_second_run_is_a_noop(tmp_path: Path) -> None:
     first = database.run_migrations(tmp_path)
     second = database.run_migrations(tmp_path)
-    assert first == ["001_initial_schema"]
+    assert first == ["001_initial_schema", "002_settings_kv"]
     assert second == []
 
 

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core import database
+from app.services import episodes
+
+
+def _open(env: Path):
+    database.run_migrations(env)
+    return database.connect(database.db_path(env))
+
+
+def test_upsert_inserts_then_updates_same_id(env: Path) -> None:
+    conn = _open(env)
+    try:
+        first = episodes.upsert(
+            conn,
+            id="ep1",
+            job_id=None,
+            original_url="https://example.test/a",
+            title="First",
+            author="Alice",
+            audio_path="/data/media/ep1.mp3",
+            artwork_path="/data/media/ep1.jpg",
+            transcript_vtt="WEBVTT\n",
+            duration_secs=120,
+        )
+        assert first.id == "ep1"
+        assert first.title == "First"
+        assert first.duration_secs == 120
+
+        second = episodes.upsert(
+            conn,
+            id="ep1",
+            job_id=None,
+            original_url="https://example.test/a",
+            title="First (updated)",
+            author="Alice",
+            audio_path="/data/media/ep1.mp3",
+            artwork_path=None,  # artwork fell back this run
+            transcript_vtt="WEBVTT\n\n1\n00:00:00.000 --> 00:00:05.000\nhello\n",
+            duration_secs=130,
+        )
+        assert second.title == "First (updated)"
+        assert second.artwork_path is None
+        assert second.duration_secs == 130
+        # pub_date must NOT have changed -- preserves the original publish moment.
+        assert second.pub_date == first.pub_date
+    finally:
+        conn.close()
+
+
+def test_list_published_orders_newest_first(env: Path) -> None:
+    conn = _open(env)
+    try:
+        for n in range(3):
+            episodes.upsert(
+                conn,
+                id=f"ep{n}",
+                job_id=None,
+                original_url=f"https://example.test/{n}",
+                title=f"Episode {n}",
+                author="A",
+                audio_path=f"/data/media/ep{n}.mp3",
+                artwork_path=None,
+                transcript_vtt="WEBVTT\n",
+                duration_secs=10 * n,
+            )
+        # Manually bump the pub_date on ep1 so we have a deterministic order
+        # independent of insert clock resolution.
+        conn.execute("UPDATE episodes SET pub_date = '2026-06-01T00:00:00Z' WHERE id = 'ep1'")
+        conn.execute("UPDATE episodes SET pub_date = '2026-05-01T00:00:00Z' WHERE id = 'ep0'")
+        conn.execute("UPDATE episodes SET pub_date = '2026-04-01T00:00:00Z' WHERE id = 'ep2'")
+
+        listed = episodes.list_published(conn)
+        assert [ep.id for ep in listed] == ["ep1", "ep0", "ep2"]
+    finally:
+        conn.close()
+
+
+def test_list_published_excludes_rows_without_audio(env: Path) -> None:
+    """A row created during finalize-failure recovery (audio_path NULL) must
+    not leak into the RSS feed."""
+
+    conn = _open(env)
+    try:
+        episodes.upsert(
+            conn,
+            id="published",
+            job_id=None,
+            original_url="https://example.test/p",
+            title="Published",
+            author="A",
+            audio_path="/data/media/published.mp3",
+            artwork_path=None,
+            transcript_vtt="WEBVTT\n",
+            duration_secs=10,
+        )
+        episodes.upsert(
+            conn,
+            id="half",
+            job_id=None,
+            original_url="https://example.test/h",
+            title="Half-finalized",
+            author="A",
+            audio_path=None,
+            artwork_path=None,
+            transcript_vtt=None,
+            duration_secs=None,
+        )
+        listed = episodes.list_published(conn)
+        assert [ep.id for ep in listed] == ["published"]
+    finally:
+        conn.close()
+
+
+def test_get_by_id_returns_none_for_unknown(env: Path) -> None:
+    conn = _open(env)
+    try:
+        assert episodes.get_by_id(conn, "missing") is None
+    finally:
+        conn.close()
+
+
+def test_latest_updated_at_tracks_most_recent_published(env: Path) -> None:
+    conn = _open(env)
+    try:
+        episodes.upsert(
+            conn,
+            id="a",
+            job_id=None,
+            original_url="https://example.test/a",
+            title=None,
+            author=None,
+            audio_path="/data/media/a.mp3",
+            artwork_path=None,
+            transcript_vtt=None,
+            duration_secs=None,
+        )
+        conn.execute("UPDATE episodes SET updated_at = '2026-06-01T00:00:00Z' WHERE id = 'a'")
+        assert episodes.latest_updated_at(conn) == "2026-06-01T00:00:00Z"
+    finally:
+        conn.close()

--- a/backend/tests/test_feed.py
+++ b/backend/tests/test_feed.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import defusedxml.ElementTree as DET
+import pytest
+from app.config import get_settings
+from app.services import feed
+from app.services.episodes import Episode
+
+_PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+_ITUNES_NS = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+
+
+def _episode(
+    *,
+    id: str = "abc123",
+    title: str = "An Article",
+    author: str = "Author Name",
+    audio_path: str | None = None,
+    artwork_path: str | None = None,
+    transcript_vtt: str | None = "WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nhi\n",
+    duration_secs: int | None = 90,
+    pub_date: str = "2026-05-28T18:00:00Z",
+) -> Episode:
+    return Episode(
+        id=id,
+        job_id="job1",
+        title=title,
+        author=author,
+        original_url=f"https://example.test/{id}",
+        audio_path=audio_path,
+        artwork_path=artwork_path,
+        transcript_vtt=transcript_vtt,
+        duration_secs=duration_secs,
+        pub_date=pub_date,
+        created_at=pub_date,
+        updated_at=pub_date,
+    )
+
+
+def _last_build() -> datetime:
+    return datetime(2026, 5, 28, 18, 0, 0, tzinfo=UTC)
+
+
+def _render(
+    episodes: list[Episode],
+    *,
+    env: Path,
+    podcast_guid: str = "11111111-2222-3333-4444-555555555555",
+) -> bytes:
+    return feed.render(
+        episodes,
+        settings=get_settings(),
+        podcast_guid=podcast_guid,
+        last_build=_last_build(),
+    )
+
+
+def test_channel_contains_required_fields(env: Path) -> None:
+    body = _render([], env=env)
+    root = DET.fromstring(body)
+    channel = root.find("channel")
+    assert channel is not None
+    assert channel.find("title").text == get_settings().FEED_TITLE
+    assert channel.find("description").text == get_settings().FEED_DESCRIPTION
+    assert channel.find("language").text == get_settings().FEED_LANGUAGE
+    assert channel.find("image/url").text == get_settings().FEED_ARTWORK_URL
+
+
+def test_channel_contains_podcast_namespace_tags(env: Path) -> None:
+    body = _render([], env=env, podcast_guid="abcdef-guid")
+    root = DET.fromstring(body)
+    channel = root.find("channel")
+    assert channel.find(f"{{{_PODCAST_NS}}}guid").text == "abcdef-guid"
+    assert channel.find(f"{{{_PODCAST_NS}}}locked").text == "yes"
+    assert channel.find(f"{{{_PODCAST_NS}}}medium").text == "podcast"
+    txt = channel.find(f"{{{_PODCAST_NS}}}txt")
+    assert txt.text and "AI" in txt.text
+    assert txt.get("purpose") == "ai-content"
+
+
+def test_channel_pc2_tags_precede_items(env: Path) -> None:
+    """The PC2 channel-level tags must come BEFORE the first <item> per the
+    Podcast Index reference feeds; some validators warn otherwise."""
+
+    ep = _episode()
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    channel = root.find("channel")
+    first_item_idx = next(i for i, child in enumerate(channel) if child.tag == "item")
+    pc2_guid_idx = next(
+        i for i, child in enumerate(channel) if child.tag == f"{{{_PODCAST_NS}}}guid"
+    )
+    assert pc2_guid_idx < first_item_idx
+
+
+def test_channel_includes_itunes_type_episodic(env: Path) -> None:
+    body = _render([], env=env)
+    root = DET.fromstring(body)
+    itunes_type = root.find(f"channel/{{{_ITUNES_NS}}}type")
+    assert itunes_type is not None
+    assert itunes_type.text == "episodic"
+
+
+def test_channel_image_has_required_subelements(env: Path) -> None:
+    """RSS 2.0 requires <url>, <title>, <link> under <image>; validators
+    reject the channel image otherwise."""
+
+    body = _render([], env=env)
+    root = DET.fromstring(body)
+    image = root.find("channel/image")
+    assert image is not None
+    assert image.find("url") is not None
+    assert image.find("title") is not None
+    assert image.find("link") is not None
+
+
+def test_channel_link_points_at_base_url_not_feed_url(env: Path) -> None:
+    """feedgen's channel <link> tracks the LAST fg.link() call. Ensure the
+    rendered channel link is BASE_URL (the website), not the feed itself."""
+
+    body = _render([], env=env)
+    root = DET.fromstring(body)
+    channel_link = root.find("channel/link")
+    assert channel_link is not None
+    assert channel_link.text == get_settings().BASE_URL
+
+
+def test_item_enclosure_uses_audio_path_filesize(env: Path, tmp_path: Path) -> None:
+    mp3 = tmp_path / "abc.mp3"
+    mp3.write_bytes(b"FAKE_MP3_BODY")  # 13 bytes
+    ep = _episode(id="abc", audio_path=str(mp3))
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    enclosure = root.find("channel/item/enclosure")
+    assert enclosure is not None
+    assert enclosure.get("type") == "audio/mpeg"
+    assert int(enclosure.get("length")) == 13
+    assert enclosure.get("url").endswith("/media/abc.mp3")
+
+
+def test_item_enclosure_missing_file_reports_zero_length(env: Path) -> None:
+    ep = _episode(id="ghost", audio_path="/data/media/ghost.mp3")
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    enclosure = root.find("channel/item/enclosure")
+    assert int(enclosure.get("length")) == 0
+
+
+def test_item_includes_itunes_duration_in_hms(env: Path) -> None:
+    ep = _episode(duration_secs=3725)  # 1h 02m 05s
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    duration_el = root.find(f"channel/item/{{{_ITUNES_NS}}}duration")
+    assert duration_el is not None
+    assert duration_el.text == "01:02:05"
+
+
+def test_item_includes_podcast_transcript_when_vtt_present(env: Path) -> None:
+    ep = _episode(transcript_vtt="WEBVTT\n")
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    transcript = root.find(f"channel/item/{{{_PODCAST_NS}}}transcript")
+    assert transcript is not None
+    assert transcript.get("type") == "text/vtt"
+    assert transcript.get("language") == get_settings().FEED_LANGUAGE
+    assert transcript.get("rel") == "captions"
+    assert transcript.get("url").endswith(f"/media/{ep.id}.vtt")
+
+
+def test_item_omits_podcast_transcript_when_no_vtt(env: Path) -> None:
+    ep = _episode(transcript_vtt=None)
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    assert root.find(f"channel/item/{{{_PODCAST_NS}}}transcript") is None
+
+
+def test_item_artwork_falls_back_to_feed_when_no_jpg(env: Path) -> None:
+    ep = _episode(artwork_path=None)
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    image = root.find(f"channel/item/{{{_ITUNES_NS}}}image")
+    assert image is not None
+    assert image.get("href") == get_settings().FEED_ARTWORK_URL
+
+
+def test_item_artwork_links_per_episode_jpg_when_present(env: Path) -> None:
+    ep = _episode(artwork_path="/data/media/abc.jpg")
+    body = _render([ep], env=env)
+    root = DET.fromstring(body)
+    image = root.find(f"channel/item/{{{_ITUNES_NS}}}image")
+    assert image.get("href").endswith(f"/media/{ep.id}.jpg")
+
+
+def test_self_link_points_at_rss_endpoint(env: Path) -> None:
+    body = _render([], env=env)
+    root = DET.fromstring(body)
+    atom_self = root.find("channel/{http://www.w3.org/2005/Atom}link[@rel='self']")
+    assert atom_self is not None
+    assert atom_self.get("href").endswith("/rss/rss.xml")
+
+
+def test_hms_handles_zero_and_negative(env: Path) -> None:
+    assert feed._hms(0) == "00:00:00"
+    assert feed._hms(-5) == "00:00:00"
+    assert feed._hms(59) == "00:00:59"
+    assert feed._hms(3600) == "01:00:00"
+    assert feed._hms(86399) == "23:59:59"
+
+
+def test_parse_iso_handles_z_suffix() -> None:
+    result = feed._parse_iso("2026-05-28T18:00:00Z")
+    assert result is not None
+    assert result.tzinfo is not None
+
+
+def test_parse_iso_returns_none_for_garbage(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="app.services.feed"):
+        assert feed._parse_iso("not-a-date") is None
+    assert any(getattr(rec, "event", "") == "feed_timestamp_parse_failed" for rec in caplog.records)

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -122,7 +122,7 @@ async def test_pipeline_marks_job_done_on_success(
 
     after = _job_after(env, job.id)
     assert after.status == "done"
-    assert after.stage == "transcript"
+    assert after.stage == "finalize"
     assert after.error is None
 
 
@@ -231,7 +231,7 @@ async def test_pipeline_retries_cleanup_on_transient_llm_provider_error(
 
     after = _job_after(env, job.id)
     assert after.status == "done"
-    assert after.stage == "transcript"
+    assert after.stage == "finalize"
     assert attempts["n"] >= 2  # retried at least once
 
 
@@ -357,7 +357,7 @@ async def test_pipeline_writes_artwork_jpg_and_reaches_transcript(
 
     after = _job_after(env, job.id)
     assert after.status == "done"
-    assert after.stage == "transcript"
+    assert after.stage == "finalize"
 
     expected_jpg = env / "media" / f"{job.episode_id}.jpg"
     assert expected_jpg.exists()
@@ -385,7 +385,7 @@ async def test_pipeline_succeeds_when_artwork_falls_back(
 
     after = _job_after(env, job.id)
     assert after.status == "done"
-    assert after.stage == "transcript"
+    assert after.stage == "finalize"
     assert not (env / "media" / f"{job.episode_id}.jpg").exists()
 
 
@@ -414,7 +414,7 @@ async def test_pipeline_transcript_stage_builds_vtt_from_chunks(
 
     after = _job_after(env, job.id)
     assert after.status == "done"
-    assert after.stage == "transcript"
+    assert after.stage == "finalize"
 
     chunks = captured["chunks"]
     assert isinstance(chunks, list) and chunks
@@ -476,6 +476,82 @@ async def test_pipeline_transcript_stage_rejects_length_mismatch(
     assert after.stage == "transcript"
     assert "transcript stage:" in (after.error or "")
     assert "pipeline state corrupted" in (after.error or "")
+
+
+async def test_pipeline_finalize_upserts_episode_row(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Phase 7: finalize must write an episodes row carrying the live
+    audio/artwork/vtt/duration produced by the prior stages."""
+
+    database.run_migrations(env)
+    _stub_full_chain(monkeypatch)
+
+    async def _fake_extract_with_title(_url, _settings):
+        return extraction.ExtractionResult(
+            markdown="raw " * 250,
+            metadata={"title": "Test Article", "author": "Test Author"},
+        )
+
+    monkeypatch.setattr(extraction, "extract", _fake_extract_with_title)
+
+    job = _seed_job(env)
+    await pipeline.process_job(job, get_settings())
+
+    after = _job_after(env, job.id)
+    assert after.status == "done"
+    assert after.stage == "finalize"
+
+    from app.services import episodes as episodes_service
+
+    conn = database.connect(database.db_path(env))
+    try:
+        row = episodes_service.get_by_id(conn, job.episode_id)
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row.title == "Test Article"
+    assert row.author == "Test Author"
+    assert row.original_url == job.url
+    assert row.audio_path and row.audio_path.endswith(f"/{job.episode_id}.mp3")
+    # No ogImage in metadata -> artwork falls back to feed-level art.
+    assert row.artwork_path is None
+    assert row.transcript_vtt and row.transcript_vtt.startswith("WEBVTT")
+    # Stubbed encode returns 2.5s; round() uses banker's rounding -> 2.
+    assert row.duration_secs == 2
+
+
+async def test_pipeline_finalize_falls_back_author_to_feed_author(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the article has no author, the episode row uses FEED_AUTHOR so
+    the iTunes author field stays populated."""
+
+    database.run_migrations(env)
+    _stub_full_chain(monkeypatch)
+
+    async def _fake_extract_no_author(_url, _settings):
+        return extraction.ExtractionResult(
+            markdown="raw " * 250,
+            metadata={"title": "No Byline"},
+        )
+
+    monkeypatch.setattr(extraction, "extract", _fake_extract_no_author)
+
+    job = _seed_job(env)
+    await pipeline.process_job(job, get_settings())
+
+    from app.services import episodes as episodes_service
+
+    conn = database.connect(database.db_path(env))
+    try:
+        row = episodes_service.get_by_id(conn, job.episode_id)
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row.author == get_settings().FEED_AUTHOR
 
 
 async def test_pipeline_transcript_stage_failure_marks_job_failed(

--- a/backend/tests/test_settings_store.py
+++ b/backend/tests/test_settings_store.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from app.core import database
+from app.services import settings_store
+
+
+def _open(env: Path):
+    database.run_migrations(env)
+    return database.connect(database.db_path(env))
+
+
+def test_get_returns_none_for_unknown_key(env: Path) -> None:
+    conn = _open(env)
+    try:
+        assert settings_store.get(conn, "missing") is None
+    finally:
+        conn.close()
+
+
+def test_set_then_get_round_trips(env: Path) -> None:
+    conn = _open(env)
+    try:
+        settings_store.set_(conn, "foo", "bar")
+        assert settings_store.get(conn, "foo") == "bar"
+    finally:
+        conn.close()
+
+
+def test_set_upserts_on_existing_key(env: Path) -> None:
+    conn = _open(env)
+    try:
+        settings_store.set_(conn, "foo", "first")
+        settings_store.set_(conn, "foo", "second")
+        assert settings_store.get(conn, "foo") == "second"
+    finally:
+        conn.close()
+
+
+def test_get_or_init_podcast_guid_persists_first_call(env: Path) -> None:
+    conn = _open(env)
+    try:
+        first = settings_store.get_or_init_podcast_guid(conn, "https://feed.example.test")
+        # Returned value is a valid uuid string.
+        parsed = uuid.UUID(first)
+        assert str(parsed) == first
+        # Persisted under the documented key so feed/render can read it back.
+        assert settings_store.get(conn, settings_store.PODCAST_GUID_KEY) == first
+    finally:
+        conn.close()
+
+
+def test_get_or_init_podcast_guid_is_stable_across_calls(env: Path) -> None:
+    conn = _open(env)
+    try:
+        a = settings_store.get_or_init_podcast_guid(conn, "https://feed.example.test")
+        b = settings_store.get_or_init_podcast_guid(conn, "https://feed.example.test")
+        assert a == b
+    finally:
+        conn.close()
+
+
+def test_get_or_init_podcast_guid_is_uuid5_of_pc2_namespace(env: Path) -> None:
+    """The Podcasting 2.0 spec mandates UUIDv5 over the PC2 namespace
+    ``ead4c236-bf58-58c6-a2c6-a6b28d128cb6`` with the scheme stripped and
+    trailing slash removed. Any other derivation produces a value no other
+    PC2-aware tool will agree with."""
+
+    conn = _open(env)
+    try:
+        pc2_ns = uuid.UUID("ead4c236-bf58-58c6-a2c6-a6b28d128cb6")
+        derived = str(uuid.uuid5(pc2_ns, "feed.example.test"))
+        stored = settings_store.get_or_init_podcast_guid(conn, "https://feed.example.test/")
+        assert stored == derived
+    finally:
+        conn.close()
+
+
+def test_canonical_feed_url_strips_scheme_and_trailing_slash() -> None:
+    assert settings_store._canonical_feed_url("https://feed.example.test/") == "feed.example.test"
+    assert (
+        settings_store._canonical_feed_url("http://feed.example.test/path/")
+        == "feed.example.test/path"
+    )
+    assert settings_store._canonical_feed_url("https://feed.example.test") == "feed.example.test"
+
+
+def test_get_or_init_returns_persisted_value_regardless_of_base_url(
+    env: Path,
+) -> None:
+    """Once a guid is stored, the function must NOT re-derive it even if the
+    operator's BASE_URL changes (the Podcasting 2.0 spec requires the guid
+    survive feed-URL changes)."""
+
+    conn = _open(env)
+    try:
+        stored = settings_store.get_or_init_podcast_guid(conn, "https://old.example.test")
+        unchanged = settings_store.get_or_init_podcast_guid(conn, "https://new.example.test")
+        assert unchanged == stored
+    finally:
+        conn.close()

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -104,7 +104,7 @@ async def test_pickup_runs_pipeline_against_a_queued_job(
     finally:
         conn.close()
     assert row["status"] == "done"
-    assert row["stage"] == "transcript"
+    assert row["stage"] == "finalize"
     assert row["error"] is None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,15 @@ dependencies = [
     "mutagen>=1.47",
     # Phase 6 artwork. Pillow reads JPEG/PNG/WebP/GIF/BMP/TIFF.
     "pillow>=10.4",
+    # Phase 7 RSS feed. feedgen renders the iTunes/Atom/PSC namespaces; PC2
+    # tags are appended via string-level XML construction afterwards because
+    # feedgen doesn't model the namespace natively.
+    "feedgen>=1.0",
+    # defusedxml.ElementTree.fromstring blocks XXE / billion-laughs / DTD
+    # retrieval that stdlib xml.etree allows by default. The feed parser
+    # only ever reads feedgen's own output (no attacker input), but
+    # defense-in-depth is cheap and the linter flags any stdlib XML parse.
+    "defusedxml>=0.7",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,9 @@ name = "audicle"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "defusedxml" },
     { name = "fastapi" },
+    { name = "feedgen" },
     { name = "httpx" },
     { name = "mutagen" },
     { name = "numpy" },
@@ -64,7 +66,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "defusedxml", specifier = ">=0.7" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "feedgen", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mutagen", specifier = ">=1.47" },
     { name = "numpy", specifier = ">=1.26" },
@@ -160,6 +164,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
@@ -174,6 +187,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d4646
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
+
+[[package]]
+name = "feedgen"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/59/be0a6f852b5dfbf19e6c8e962c8f41407697f9f52a7902250ed98683ae89/feedgen-1.0.0.tar.gz", hash = "sha256:d9bd51c3b5e956a2a52998c3708c4d2c729f2fcc311188e1e5d3b9726393546a", size = 258496, upload-time = "2023-12-25T18:04:08.421Z" }
 
 [[package]]
 name = "filelock"
@@ -287,6 +310,68 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
 ]
 
 [[package]]
@@ -626,6 +711,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -702,6 +799,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pipeline now runs **extract -> cleanup -> corrections -> chunk -> tts -> audio -> artwork -> transcript -> finalize**; final `status=done` with `stage=finalize`. Finalize upserts an episodes row carrying the in-memory audio/artwork/vtt/duration.
- `services/feed.py`: feedgen for Atom + iTunes namespaces; PC2 (`podcast:`) namespace layered on via `defusedxml`-based string XML. Channel: `itunes:type=episodic`, `podcast:medium=podcast`, `podcast:guid` (UUIDv5 over the PC2-spec namespace + canonicalized URL), `podcast:locked` + `podcast:txt purpose="ai-content"`. Per-item: enclosure with on-disk length, `itunes:duration HH:MM:SS`, `podcast:transcript` pointing at `/media/{id}.vtt`. `<image>` carries `<url>+<title>+<link>` per RSS 2.0. Namespaces registered at module load so the round-trip preserves `atom:/itunes:/podcast:` instead of emitting `ns0:/ns1:`.
- `services/episodes.py`: Episode dataclass + upsert/get_by_id/list_published (filters null audio_path) + latest_updated_at.
- `services/settings_store.py`: k/v store + `get_or_init_podcast_guid` using the PC2 namespace UUID and canonicalized feed URL (scheme stripped, trailing slash removed).
- `api/rss.py`: `GET /rss/rss.xml` with `Last-Modified` + `Cache-Control` + `If-Modified-Since -> 304`.
- `api/media.py`: `GET /media/{id}.mp3` and `.jpg` from disk via FileResponse; `.vtt` from the episode row's `transcript_vtt` column with 86400s cache. `episode_id` validated against a strict allowlist regex inside the handler (defense-in-depth above the route pattern).
- Migration `002_settings_kv` appends a `settings(key, value, updated_at)` table. Phase 1 schema is untouched.

## Test plan

- [x] `uv run pytest` — 245 passed (+43 vs main)
- [x] `uv run ruff check backend` — All checks passed
- [x] `uv run ruff format --check backend` — clean
- [x] Container smoke (`tmp/phase7_smoke.sh`) — Pillow + feedgen + lxml + defusedxml load in slim image; renders 2.1 KB RSS with stable `podcast:guid`, `itunes:duration=00:02:05`; serves mp3/jpg/vtt with correct content-types; `If-Modified-Since -> 304` round-trip verified
- [x] Pre-existing pipeline + worker stage assertions updated for new terminal stage (`transcript -> finalize`)