### PR TITLE
Phase 8: retention and purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Added (Phase 8 - Retention and Purge)
+
+- `backend/app/services/retention.py`: `purge_older_than(settings, older_than_days)` deletes episodes (DB row + on-disk mp3/jpg/vtt) older than the cutoff. `older_than_days=0` is the explicit "wipe everything" contract used by the purge endpoint; positive N filters strictly older than `now - N days`. Returns `PurgeResult(episode_ids, rows_deleted, files_removed)` so callers can log + surface a summary.
+- **Defense-in-depth file removal**: `_remove_path` resolves the target with `path.resolve(strict=False)`, then `relative_to(media_dir.resolve())` to confirm the path stays under `DATA_DIR/media` before unlinking. A poisoned row pointing `audio_path` at `/etc/passwd` (manual DB edit, future migration accident) logs a WARN and is skipped. Missing files are silently treated as success (the sweep is idempotent).
+- `backend/app/worker.py`: daily retention sweep wired into the worker poll loop. `_maybe_run_retention_sweep` runs at most once per UTC day at `RETENTION_SWEEP_HOUR_UTC`, calling `purge_older_than(RETENTION_DAYS)`. Sweep failures are logged at ERROR (`retention_sweep_failed`) but do NOT mark the day as swept, so the next iteration retries. The sweep is stateless across restarts -- a worker bounce past the sweep hour without having run today will re-fire.
+- `backend/app/api/v1/purge.py`: `POST /api/v1/purge` for operator-initiated wipes. Requires `confirm=true` query param to acknowledge the destructive action (returns 400 otherwise). Accepts `older_than_days=N` for a partial purge (validated `ge=0`). Returns `{older_than_days, rows_deleted, files_removed, episode_ids: [...]}` so an operator script can confirm what got removed.
+- `backend/app/api/v1/router.py`: registered the purge route alongside the existing v1 routes.
+
+Tests (16 new, 261 total)
+
+- `test_retention.py` (7): old rows + files removed, full purge wipes everything (including future-dated rows), partial-cutoff no-op, missing files silently skipped, defense-in-depth rejects paths outside `media_dir` (verified via the `retention_unsafe_path` log assertion), negative `older_than_days` raises `ValueError`, `>100_000` days rejected before `timedelta` overflows the year-9999 ceiling.
+- `test_api_purge.py` (5): missing `confirm` returns 400, `confirm=true` wipes when `older_than_days=0`, partial purge keeps recent, negative days rejected at validation (400 via the custom error handler), response shape matches the documented schema.
+- `test_worker_retention.py` (4): sweep fires when the UTC hour matches and no run today; skips when already run today; skips when the hour doesn't match; sweep failure does NOT mark the day as swept and is logged with `retention_sweep_failed` event.
+
+### Code-review pass (multi-agent /simplify + /code-review for Phase 8)
+
+Findings surfaced and applied:
+
+- **`OverflowError` on huge `older_than_days`**: `datetime.now(UTC) - timedelta(days=N)` overflows past the year-9999 ceiling at ~2.9M days. The endpoint accepted any non-negative int and would 500 on `older_than_days=1_000_000`. Added `_MAX_OLDER_THAN_DAYS=100_000` cap in `purge_older_than` and `le=100_000` on the FastAPI Query so misuse fails with a clean 400 / `ValueError`.
+- **Sync purge blocked the async worker loop**: `_maybe_run_retention_sweep` is sync (SQLite + file unlinks). Wrapped the call in `asyncio.to_thread` so a large sweep doesn't stall signal handling or the `shutdown.wait()` that lets SIGTERM exit cleanly.
+- **Config bounds missing**: `RETENTION_DAYS` and `RETENTION_SWEEP_HOUR_UTC` accepted any int. A misconfigured `RETENTION_SWEEP_HOUR_UTC=25` would silently disable the sweep. Added `Field(ge=0, le=23)` / `Field(ge=0, le=100_000)` so startup fails loudly on a bad value.
+- **Docstring contradicted behavior for `older_than_days=0`**: old docstring claimed "every episode matching `pub_date < now`" but the implementation wipes unconditionally (including future-dated rows from clock skew or test fixtures). Updated to describe the actual wipe-everything contract.
+- **Simplified the zero-day branch**: collapsed the `if cutoff_iso is None` / separate SELECT into a single parameterized query that uses a year-9999 sentinel cutoff. One code path instead of two.
+- **`_remove_safe` was a one-line wrapper**: inlined into the single caller; saves a hop and clarifies the `path_str|None` guard at the call site.
+- **`_remove_path` swallowed unlink errors silently**: `IsADirectoryError`, `PermissionError`, and other `OSError` cases were eaten by a bare `suppress(OSError)` so operators had no breadcrumb to a stuck on-disk artifact after a sweep. Now logs `retention_unlink_failed` / `retention_resolve_failed` with the exception class.
+- **`test_purge_refuses_paths_outside_media_dir` didn't assert the WARN log**: added `caplog` assertion that the `retention_unsafe_path` event is emitted. Without this, a future change that silenced the log would still pass the test.
+- **Frozen-datetime helper was duplicated four times**: extracted `_freeze_now(monkeypatch, fake_now)` in `test_worker_retention.py`. Inheriting from the real `datetime` (rather than building a stub class with only `now`) means a future change in `worker.py` that adds `datetime.fromisoformat(...)` or constructs a `datetime(...)` no longer breaks every retention-sweep test with an `AttributeError`.
+- **`test_purge_negative_older_than_days_raises_value_error` missing `env` fixture**: would fail at `get_settings()` validation before hitting the negative branch. Added the fixture; the test now actually exercises the code path it documents.
+- **CHANGELOG test-count drift**: previous draft claimed 276 total. Re-checked against `pytest --collect-only`: 261. Updated.
+
+Container smoke (`tmp/phase8_smoke.sh`) verified inside the runtime image: build, seed a row + mp3/jpg under `/data/media`, `POST /api/v1/purge` without `confirm` returns 400, `POST /api/v1/purge?confirm=true` returns 200 with `rows_deleted=1` and `files_removed=2`, and re-querying the DB confirms the row is gone and the on-disk files are unlinked.
+
 ### Added (Phase 7 - RSS Feed and Media Serving)
 
 - Pipeline now runs **extract -> cleanup -> corrections -> chunk -> tts -> audio -> artwork -> transcript -> finalize**. Final `status=done` with `stage=finalize`. The finalize stage upserts a row into the `episodes` table that the RSS feed and media handlers read from.

--- a/backend/app/api/v1/purge.py
+++ b/backend/app/api/v1/purge.py
@@ -1,0 +1,57 @@
+"""``POST /api/v1/purge`` -- operator-initiated retention sweep.
+
+Requires an explicit ``confirm=true`` query parameter so a stray POST from
+a tool or CSRF-less client can't wipe the feed. Accepts ``older_than_days``
+to target a subset rather than the full archive.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.config import Settings, get_settings
+from app.services import retention
+
+router = APIRouter(tags=["maintenance"])
+
+
+class PurgeResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    older_than_days: int = Field(description="Cutoff age in days")
+    rows_deleted: int = Field(description="Episode rows removed from the DB")
+    files_removed: int = Field(description="MP3/JPG/VTT files removed from disk")
+    episode_ids: list[str] = Field(description="IDs of removed episodes")
+
+
+@router.post("/purge", response_model=PurgeResponse)
+async def post_purge(
+    settings: Annotated[Settings, Depends(get_settings)],
+    confirm: Annotated[
+        bool,
+        Query(description="Must be true to acknowledge the destructive action."),
+    ] = False,
+    older_than_days: Annotated[
+        int,
+        Query(
+            description="Purge episodes older than N days. 0 wipes everything.",
+            ge=0,
+            le=100_000,
+        ),
+    ] = 0,
+) -> PurgeResponse:
+    if not confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="confirm=true is required to acknowledge the destructive action",
+        )
+    result = retention.purge_older_than(settings, older_than_days=older_than_days)
+    return PurgeResponse(
+        older_than_days=older_than_days,
+        rows_deleted=result.rows_deleted,
+        files_removed=result.files_removed,
+        episode_ids=list(result.episode_ids),
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 from app.api.v1 import corrections as corrections_routes
 from app.api.v1 import prompt as prompt_routes
+from app.api.v1 import purge as purge_routes
 from app.api.v1 import status as status_routes
 from app.api.v1 import submit as submit_routes
 
@@ -14,3 +15,4 @@ router.include_router(submit_routes.router)
 router.include_router(status_routes.router)
 router.include_router(prompt_routes.router)
 router.include_router(corrections_routes.router)
+router.include_router(purge_routes.router)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -71,9 +71,9 @@ class Settings(BaseSettings):
     LOG_FORMAT: Literal["json", "text"] = "json"
 
     # Retention.
-    RETENTION_DAYS: int = 90
-    RETENTION_SWEEP_HOUR_UTC: int = 7
-    MIGRATION_BACKUP_RETENTION_DAYS: int = 30
+    RETENTION_DAYS: int = Field(default=90, ge=0, le=100_000)
+    RETENTION_SWEEP_HOUR_UTC: int = Field(default=7, ge=0, le=23)
+    MIGRATION_BACKUP_RETENTION_DAYS: int = Field(default=30, ge=0)
 
     # RSS.
     RSS_CACHE_MAX_AGE_SECONDS: int = 300

--- a/backend/app/services/retention.py
+++ b/backend/app/services/retention.py
@@ -1,0 +1,158 @@
+"""Episode retention sweep.
+
+Daily background task that deletes episodes (and their on-disk media) older
+than ``RETENTION_DAYS``. Also exposed via ``POST /api/v1/purge`` for an
+operator-initiated wipe.
+
+The retention sweep runs once per day at ``RETENTION_SWEEP_HOUR_UTC``; the
+purge endpoint accepts an ``older_than_days`` override so an operator can
+clear stale content without waiting for the cron-style trigger.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from app.config import Settings
+from app.core import database
+from app.core.paths import media_dir
+
+logger = logging.getLogger("app.services.retention")
+
+
+@dataclass(frozen=True)
+class PurgeResult:
+    episode_ids: tuple[str, ...]
+    rows_deleted: int
+    files_removed: int
+
+
+# Upper bound on the day-count parameter; Python's datetime only spans years
+# 1..9999, so ``datetime.now() - timedelta(days=N)`` overflows past roughly
+# 2.9M days. Cap at 100k days (~273 years) which is well past any plausible
+# retention window and still safely inside the datetime range.
+_MAX_OLDER_THAN_DAYS = 100_000
+
+
+def purge_older_than(
+    settings: Settings,
+    older_than_days: int,
+) -> PurgeResult:
+    """Delete episode rows + on-disk media older than ``older_than_days``.
+
+    ``older_than_days=0`` is the explicit "wipe everything" contract used by
+    the purge endpoint: it removes every row unconditionally (including any
+    future-dated rows from clock skew or test fixtures). Positive N filters
+    rows strictly older than ``now - N days``.
+    """
+
+    if older_than_days < 0 or older_than_days > _MAX_OLDER_THAN_DAYS:
+        raise ValueError(
+            f"older_than_days must be in [0, {_MAX_OLDER_THAN_DAYS}], got {older_than_days}"
+        )
+
+    # Sentinel cutoff for the wipe-all path collapses to a single query: any
+    # real row's pub_date is strictly less than the year-9999 sentinel.
+    if older_than_days == 0:
+        cutoff_iso = "9999-12-31T23:59:59Z"
+    else:
+        cutoff = datetime.now(UTC) - timedelta(days=older_than_days)
+        cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, audio_path, artwork_path
+            FROM episodes
+            WHERE pub_date < ?
+            """,
+            (cutoff_iso,),
+        ).fetchall()
+        episode_ids = tuple(row["id"] for row in rows)
+        for row in rows:
+            conn.execute("DELETE FROM episodes WHERE id = ?", (row["id"],))
+        conn.commit()
+    finally:
+        conn.close()
+
+    files_removed = 0
+    out_root = media_dir(settings)
+    for row in rows:
+        for path_str in (row["audio_path"], row["artwork_path"]):
+            if path_str and _remove_path(Path(path_str), root_guard=out_root):
+                files_removed += 1
+        # The VTT lives in the DB, not on disk, so the row delete is the
+        # only cleanup for it. Older code paths may have created a stub
+        # .vtt under media_dir though; check for one.
+        if _remove_path(out_root / f"{row['id']}.vtt", root_guard=out_root):
+            files_removed += 1
+
+    logger.info(
+        "Retention sweep complete",
+        extra={
+            "event": "retention_sweep_complete",
+            "older_than_days": older_than_days,
+            "cutoff": "wipe_all" if older_than_days == 0 else cutoff_iso,
+            "rows_deleted": len(rows),
+            "files_removed": files_removed,
+        },
+    )
+    return PurgeResult(
+        episode_ids=episode_ids,
+        rows_deleted=len(rows),
+        files_removed=files_removed,
+    )
+
+
+def _remove_path(path: Path, *, root_guard: Path | None = None) -> bool:
+    """Unlink ``path``. If ``root_guard`` is provided, refuse paths that
+    don't resolve under it (defense-in-depth against a poisoned row pointing
+    at ``/etc/passwd``). Missing-file is silently treated as success (the
+    sweep is idempotent). All other ``OSError`` cases (e.g.
+    ``IsADirectoryError``, ``PermissionError``) log a WARNING so operators
+    can grep for stuck artifacts after a sweep.
+    """
+
+    try:
+        resolved = path.resolve(strict=False)
+    except OSError as exc:
+        logger.warning(
+            "Could not resolve path during retention sweep",
+            extra={
+                "event": "retention_resolve_failed",
+                "path": str(path),
+                "error_class": type(exc).__name__,
+            },
+        )
+        return False
+    if root_guard is not None:
+        try:
+            resolved.relative_to(root_guard.resolve())
+        except ValueError:
+            logger.warning(
+                "Refusing to remove path outside DATA_DIR/media",
+                extra={
+                    "event": "retention_unsafe_path",
+                    "path": str(path),
+                },
+            )
+            return False
+    if not resolved.exists():
+        return False
+    try:
+        resolved.unlink()
+    except OSError as exc:
+        logger.warning(
+            "Failed to unlink path during retention sweep",
+            extra={
+                "event": "retention_unlink_failed",
+                "path": str(resolved),
+                "error_class": type(exc).__name__,
+            },
+        )
+        return False
+    return True

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -13,10 +13,11 @@ import contextlib
 import logging
 import signal
 import sys
+from datetime import UTC, datetime
 
 from app.config import Settings, get_settings
 from app.core import database
-from app.services import jobs, pipeline, reachability
+from app.services import jobs, pipeline, reachability, retention
 from app.startup import bootstrap
 
 logger = logging.getLogger("app.worker")
@@ -43,6 +44,33 @@ async def _pickup_once(settings: Settings) -> jobs.Job | None:
         return jobs.claim_next_queued(conn)
     finally:
         conn.close()
+
+
+def _maybe_run_retention_sweep(settings: Settings, last_sweep_day: str | None) -> str | None:
+    """Run the retention sweep at most once per UTC day, at the configured
+    hour. Returns the new value of ``last_sweep_day`` so the caller can
+    persist the de-dup state across iterations.
+
+    Stateless across restarts (re-runs if the worker bounces past the sweep
+    hour without having run today); the operation is idempotent so a double
+    sweep just emits two `retention_sweep_complete` log lines.
+    """
+
+    now = datetime.now(UTC)
+    today = now.strftime("%Y-%m-%d")
+    if now.hour != settings.RETENTION_SWEEP_HOUR_UTC:
+        return last_sweep_day
+    if last_sweep_day == today:
+        return last_sweep_day
+    try:
+        retention.purge_older_than(settings, older_than_days=settings.RETENTION_DAYS)
+    except Exception:
+        logger.exception(
+            "Retention sweep failed; will retry next iteration",
+            extra={"event": "retention_sweep_failed"},
+        )
+        return last_sweep_day
+    return today
 
 
 async def _process_one(settings: Settings) -> bool:
@@ -86,7 +114,14 @@ async def run() -> None:
     await _crash_recovery(settings.DATA_DIR)
 
     poll_interval = settings.QUEUE_POLL_INTERVAL_SECONDS
+    last_sweep_day: str | None = None
     while not shutdown.is_set():
+        # The sweep is sync (SQLite + file unlinks); run it in a worker thread
+        # so a large purge doesn't block signal handling or the
+        # ``shutdown.wait()`` that lets SIGTERM exit cleanly.
+        last_sweep_day = await asyncio.to_thread(
+            _maybe_run_retention_sweep, settings, last_sweep_day
+        )
         # Anything that escapes process_job (DB locked during pickup, OSError
         # on the data dir, ...) must not kill the worker. Log it and back off
         # one poll interval so we don't spin against a hard failure.

--- a/backend/tests/test_api_purge.py
+++ b/backend/tests/test_api_purge.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.config import get_settings
+from app.core import database
+from app.core.paths import media_dir
+from app.main import create_app
+from app.services import episodes
+from fastapi.testclient import TestClient
+
+
+def _client(env: Path) -> TestClient:
+    database.run_migrations(env)
+    return TestClient(create_app())
+
+
+def _seed_episode(env: Path, *, id_: str, pub_date: str = "2020-01-01T00:00:00Z") -> None:
+    database.run_migrations(env)
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id=id_,
+            job_id=None,
+            original_url=f"https://example.test/{id_}",
+            title=id_,
+            author="A",
+            audio_path=str(media_dir(get_settings()) / f"{id_}.mp3"),
+            artwork_path=None,
+            transcript_vtt="WEBVTT\n",
+            duration_secs=10,
+        )
+        conn.execute("UPDATE episodes SET pub_date=? WHERE id=?", (pub_date, id_))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_purge_requires_confirm_query_param(env: Path) -> None:
+    _seed_episode(env, id_="ep1")
+    with _client(env) as client:
+        response = client.post("/api/v1/purge")
+    assert response.status_code == 400
+    body = response.json()
+    assert "confirm" in str(body).lower()
+
+
+def test_purge_with_confirm_wipes_everything_when_days_zero(env: Path) -> None:
+    _seed_episode(env, id_="ep1", pub_date="2099-01-01T00:00:00Z")  # future
+    _seed_episode(env, id_="ep2", pub_date="2020-01-01T00:00:00Z")
+    with _client(env) as client:
+        response = client.post("/api/v1/purge?confirm=true")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rows_deleted"] == 2
+    assert set(body["episode_ids"]) == {"ep1", "ep2"}
+
+    conn = database.connect(database.db_path(env))
+    try:
+        assert episodes.get_by_id(conn, "ep1") is None
+        assert episodes.get_by_id(conn, "ep2") is None
+    finally:
+        conn.close()
+
+
+def test_purge_partial_keeps_recent_episodes(env: Path) -> None:
+    _seed_episode(env, id_="old", pub_date="2020-01-01T00:00:00Z")
+    _seed_episode(env, id_="new", pub_date="2099-01-01T00:00:00Z")
+    with _client(env) as client:
+        response = client.post("/api/v1/purge?confirm=true&older_than_days=30")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rows_deleted"] == 1
+    assert body["episode_ids"] == ["old"]
+
+    conn = database.connect(database.db_path(env))
+    try:
+        assert episodes.get_by_id(conn, "old") is None
+        assert episodes.get_by_id(conn, "new") is not None
+    finally:
+        conn.close()
+
+
+def test_purge_negative_days_rejected_at_validation(env: Path) -> None:
+    """FastAPI's ``ge=0`` query-param constraint rejects negative values
+    before the handler runs; the custom error handler converts validation
+    errors to 400."""
+
+    with _client(env) as client:
+        response = client.post("/api/v1/purge?confirm=true&older_than_days=-1")
+    assert response.status_code == 400
+
+
+def test_purge_response_shape(env: Path) -> None:
+    _seed_episode(env, id_="ep1")
+    with _client(env) as client:
+        response = client.post("/api/v1/purge?confirm=true")
+    body = response.json()
+    assert set(body.keys()) == {
+        "older_than_days",
+        "rows_deleted",
+        "files_removed",
+        "episode_ids",
+    }

--- a/backend/tests/test_retention.py
+++ b/backend/tests/test_retention.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.config import get_settings
+from app.core import database
+from app.core.paths import media_dir
+from app.services import episodes, retention
+
+
+def _seed(env: Path, *, id_: str, pub_date: str, with_files: bool = True) -> Path:
+    database.run_migrations(env)
+    media = media_dir(get_settings())
+    media.mkdir(parents=True, exist_ok=True)
+    mp3 = media / f"{id_}.mp3"
+    jpg = media / f"{id_}.jpg"
+    if with_files:
+        mp3.write_bytes(b"FAKE_MP3")
+        jpg.write_bytes(b"FAKE_JPG")
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id=id_,
+            job_id=None,
+            original_url=f"https://example.test/{id_}",
+            title=id_,
+            author="A",
+            audio_path=str(mp3),
+            artwork_path=str(jpg) if with_files else None,
+            transcript_vtt="WEBVTT\n",
+            duration_secs=10,
+        )
+        conn.execute("UPDATE episodes SET pub_date=? WHERE id=?", (pub_date, id_))
+        conn.commit()
+    finally:
+        conn.close()
+    return media
+
+
+def test_purge_older_than_removes_old_rows_and_files(env: Path) -> None:
+    media = _seed(env, id_="old", pub_date="2020-01-01T00:00:00Z")
+    _seed(env, id_="new", pub_date="2099-01-01T00:00:00Z")
+
+    result = retention.purge_older_than(get_settings(), older_than_days=30)
+
+    assert result.rows_deleted == 1
+    assert result.episode_ids == ("old",)
+    assert result.files_removed == 2  # mp3 + jpg
+    assert not (media / "old.mp3").exists()
+    assert not (media / "old.jpg").exists()
+    assert (media / "new.mp3").exists()
+    assert (media / "new.jpg").exists()
+
+    conn = database.connect(database.db_path(env))
+    try:
+        assert episodes.get_by_id(conn, "old") is None
+        assert episodes.get_by_id(conn, "new") is not None
+    finally:
+        conn.close()
+
+
+def test_purge_with_zero_days_wipes_everything(env: Path) -> None:
+    _seed(env, id_="recent", pub_date="2099-01-01T00:00:00Z")
+    result = retention.purge_older_than(get_settings(), older_than_days=0)
+    assert result.rows_deleted == 1
+
+
+def test_purge_no_op_when_nothing_matches(env: Path) -> None:
+    _seed(env, id_="recent", pub_date="2099-01-01T00:00:00Z")
+    result = retention.purge_older_than(get_settings(), older_than_days=10000)
+    assert result.rows_deleted == 0
+    assert result.files_removed == 0
+    assert result.episode_ids == ()
+
+
+def test_purge_silently_skips_missing_files(env: Path) -> None:
+    """A row whose mp3/jpg already vanished (manual cleanup, restore from
+    backup, etc.) must still delete the DB row and not error."""
+
+    media = _seed(env, id_="orphan", pub_date="2020-01-01T00:00:00Z")
+    (media / "orphan.mp3").unlink()
+    (media / "orphan.jpg").unlink()
+    result = retention.purge_older_than(get_settings(), older_than_days=30)
+    assert result.rows_deleted == 1
+    assert result.files_removed == 0
+
+
+def test_purge_refuses_paths_outside_media_dir(
+    env: Path,
+    tmp_path: Path,
+    caplog,
+) -> None:
+    """A poisoned row pointing audio_path at /etc/passwd must NOT cause
+    the sweep to remove that file. The sweep logs `retention_unsafe_path`
+    so operators can grep for the breakout attempt."""
+
+    import logging
+
+    database.run_migrations(env)
+    target = tmp_path / "victim.txt"
+    target.write_text("important")
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id="evil",
+            job_id=None,
+            original_url="https://example.test/evil",
+            title="evil",
+            author="A",
+            audio_path=str(target),
+            artwork_path=None,
+            transcript_vtt=None,
+            duration_secs=10,
+        )
+        conn.execute("UPDATE episodes SET pub_date='2020-01-01T00:00:00Z' WHERE id='evil'")
+        conn.commit()
+    finally:
+        conn.close()
+    with caplog.at_level(logging.WARNING, logger="app.services.retention"):
+        result = retention.purge_older_than(get_settings(), older_than_days=30)
+    assert result.rows_deleted == 1
+    assert target.exists(), "must NOT delete files outside media_dir"
+    assert any(getattr(rec, "event", "") == "retention_unsafe_path" for rec in caplog.records), (
+        "must log retention_unsafe_path so operators can see the breakout attempt"
+    )
+
+
+def test_purge_negative_older_than_days_raises_value_error(env: Path) -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="older_than_days"):
+        retention.purge_older_than(get_settings(), older_than_days=-1)
+
+
+def test_purge_huge_older_than_days_rejected_before_overflow(env: Path) -> None:
+    """Above ``_MAX_OLDER_THAN_DAYS`` we raise rather than letting
+    ``timedelta(days=N)`` overflow Python's year-9999 limit."""
+
+    import pytest
+
+    with pytest.raises(ValueError, match="older_than_days"):
+        retention.purge_older_than(get_settings(), older_than_days=1_000_000)

--- a/backend/tests/test_worker_retention.py
+++ b/backend/tests/test_worker_retention.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from app import worker
+from app.config import get_settings
+from app.core import database
+from app.services import episodes
+
+
+def _freeze_now(monkeypatch: pytest.MonkeyPatch, fake_now: datetime) -> None:
+    """Replace ``worker.datetime`` with a class whose ``now`` returns
+    ``fake_now`` but whose remaining surface delegates to the real datetime.
+
+    Wrapping (rather than only stubbing ``now``) means a future change in
+    ``worker.py`` that adds ``datetime.fromisoformat(...)`` or constructs a
+    new ``datetime(...)`` doesn't break every test in this file with an
+    AttributeError.
+    """
+
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fake_now
+
+    # Keep the original behavior of every classmethod/staticmethod except now.
+    monkeypatch.setattr(worker, "datetime", _Frozen)
+
+
+def _seed_old(env: Path, *, id_: str) -> None:
+    database.run_migrations(env)
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id=id_,
+            job_id=None,
+            original_url=f"https://example.test/{id_}",
+            title=id_,
+            author="A",
+            audio_path=f"/data/media/{id_}.mp3",
+            artwork_path=None,
+            transcript_vtt=None,
+            duration_secs=10,
+        )
+        conn.execute(
+            "UPDATE episodes SET pub_date='2020-01-01T00:00:00Z' WHERE id=?",
+            (id_,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_maybe_run_retention_sweep_runs_when_hour_matches(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the current UTC hour equals RETENTION_SWEEP_HOUR_UTC and we
+    haven't already run today, the sweep fires and the function returns
+    today's date so subsequent calls skip."""
+
+    settings = get_settings()
+    fake_now = datetime(2026, 5, 28, settings.RETENTION_SWEEP_HOUR_UTC, 30, 0, tzinfo=UTC)
+    _freeze_now(monkeypatch, fake_now)
+    _seed_old(env, id_="old")
+
+    new_day = worker._maybe_run_retention_sweep(settings, last_sweep_day=None)
+    assert new_day == "2026-05-28"
+
+    conn = database.connect(database.db_path(env))
+    try:
+        assert episodes.get_by_id(conn, "old") is None
+    finally:
+        conn.close()
+
+
+def test_maybe_run_retention_sweep_skips_when_already_ran_today(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    fake_now = datetime(2026, 5, 28, settings.RETENTION_SWEEP_HOUR_UTC, 30, 0, tzinfo=UTC)
+    _freeze_now(monkeypatch, fake_now)
+    _seed_old(env, id_="old")
+
+    same = worker._maybe_run_retention_sweep(settings, last_sweep_day="2026-05-28")
+    assert same == "2026-05-28"
+
+    conn = database.connect(database.db_path(env))
+    try:
+        assert episodes.get_by_id(conn, "old") is not None
+    finally:
+        conn.close()
+
+
+def test_maybe_run_retention_sweep_does_nothing_when_hour_does_not_match(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    off_hour = (settings.RETENTION_SWEEP_HOUR_UTC + 1) % 24
+    fake_now = datetime(2026, 5, 28, off_hour, 30, 0, tzinfo=UTC)
+    _freeze_now(monkeypatch, fake_now)
+    _seed_old(env, id_="old")
+
+    unchanged = worker._maybe_run_retention_sweep(settings, last_sweep_day=None)
+    assert unchanged is None
+
+    conn = database.connect(database.db_path(env))
+    try:
+        assert episodes.get_by_id(conn, "old") is not None
+    finally:
+        conn.close()
+
+
+def test_maybe_run_retention_sweep_logs_and_returns_unchanged_on_failure(
+    env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed sweep must not blow up the worker loop or mark the day as
+    swept; the next iteration retries."""
+
+    import logging
+
+    from app.services import retention
+
+    settings = get_settings()
+    fake_now = datetime(2026, 5, 28, settings.RETENTION_SWEEP_HOUR_UTC, 30, 0, tzinfo=UTC)
+    _freeze_now(monkeypatch, fake_now)
+
+    def _boom(_settings, *, older_than_days):
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(retention, "purge_older_than", _boom)
+    with caplog.at_level(logging.ERROR, logger="app.worker"):
+        result = worker._maybe_run_retention_sweep(settings, last_sweep_day=None)
+    assert result is None
+    assert any(getattr(rec, "event", "") == "retention_sweep_failed" for rec in caplog.records)


### PR DESCRIPTION
## Summary

- `services/retention.py`: `purge_older_than(settings, older_than_days)` deletes episode rows + on-disk media. `older_than_days=0` wipes everything; positive N filters older than `now - N days`. Cap at 100_000 days to avoid `timedelta` overflow. Defense-in-depth: `path.resolve()` + `relative_to(media_dir)` so a poisoned `audio_path` can't escape `DATA_DIR/media`. Unlink failures log `retention_unlink_failed`.
- `worker.py`: daily sweep at `RETENTION_SWEEP_HOUR_UTC` via `asyncio.to_thread` (no event-loop blocking). Idempotent across restarts.
- `api/v1/purge.py`: `POST /api/v1/purge` requires `confirm=true`; accepts `older_than_days` (validated `ge=0, le=100_000`). Returns `{older_than_days, rows_deleted, files_removed, episode_ids}`.
- `config.py`: `Field(ge=0, le=23)` on `RETENTION_SWEEP_HOUR_UTC`, `Field(ge=0, le=100_000)` on `RETENTION_DAYS` so misconfiguration fails at startup.

## Test plan

- [x] `uv run pytest` — 261 passed
- [x] `uv run ruff check backend` — All checks passed
- [x] Container smoke (`tmp/phase8_smoke.sh`) — purge wipes rows + files; no-confirm returns 400