### PR TITLE
Phase 10: runtime settings + episodes admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Added (Phase 10 - Runtime Settings + Episodes Admin)
+
+- `backend/app/services/runtime_settings.py`: operator-tunable settings backed by the new `runtime_settings` table. An explicit `ALLOWED_KEYS` allowlist gates writes so an attacker can't flip `DATA_DIR` or `SESSION_SECRET_KEY` through the admin UI.
+- `backend/app/api/v1/settings.py`: `GET /api/v1/settings` returns `{allowlist, values}`; `PUT /api/v1/settings` accepts a partial dict and persists each allowlisted key. Values are coerced back to the declared `Settings` field type on read so `RETENTION_DAYS=30` round-trips as `int` not `str`. Unknown keys return 400 with the allowlist in the error body. PUT requires `require_admin`.
+- `backend/app/api/v1/episodes.py`: `GET /api/v1/episodes` paginates (`page` + `per_page`) and emits `X-Total-Count`; `DELETE /api/v1/episodes/{id}` removes the row and any associated mp3/jpg via the Phase-8 defense-in-depth `_remove_path` helper. Both require `require_admin`.
+- Migration `004_runtime_settings` appends `runtime_settings(key PRIMARY KEY, value, updated_at)`. Phase 1-3 schemas untouched.
+
+Tests (8 new, 295 total): GET/PUT round-trip with type coercion (`int`, `bool`, `str`), unknown-key rejection with allowlist in the error body, pagination + `X-Total-Count` header, delete with file cleanup, 404 on missing episode.
+
 ### Added (Phase 9 - Authentication)
 
 - **Optional single-admin auth**: `AUTH_ENABLED=false` (the default) leaves the admin endpoints open for a single-operator localhost install. Flipping `AUTH_ENABLED=true` requires `ADMIN_PASSWORD_HASH` (bcrypt) and `SESSION_SECRET_KEY` (validated at startup; missing values raise a Pydantic `ValueError` so the process exits rather than silently serving the admin UI unauthenticated).

--- a/backend/app/api/v1/episodes.py
+++ b/backend/app/api/v1/episodes.py
@@ -1,0 +1,109 @@
+"""``GET /api/v1/episodes`` and ``DELETE /api/v1/episodes/{id}`` -- admin UI.
+
+The list endpoint paginates via ``page`` + ``per_page`` query params and
+returns ``X-Total-Count`` so the UI can render a footer. Delete removes
+the DB row + on-disk media via the existing retention helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.api.deps import require_admin
+from app.config import Settings, get_settings
+from app.core import database
+from app.core.paths import media_dir
+from app.services import episodes as episodes_service
+from app.services.retention import _remove_path
+
+router = APIRouter(tags=["episodes"])
+
+
+class EpisodeListItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    title: str | None
+    author: str | None
+    original_url: str
+    audio_path: str | None
+    artwork_path: str | None
+    duration_secs: int | None
+    pub_date: str
+    updated_at: str
+
+
+@router.get(
+    "/episodes",
+    response_model=list[EpisodeListItem],
+    dependencies=[Depends(require_admin)],
+)
+async def list_episodes(
+    response: Response,
+    settings: Annotated[Settings, Depends(get_settings)],
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=500)] = 50,
+) -> list[EpisodeListItem]:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        all_rows = episodes_service.list_published(conn)
+        total = len(all_rows)
+        start = (page - 1) * per_page
+        page_rows = all_rows[start : start + per_page]
+    finally:
+        conn.close()
+    response.headers["X-Total-Count"] = str(total)
+    return [
+        EpisodeListItem(
+            id=ep.id,
+            title=ep.title,
+            author=ep.author,
+            original_url=ep.original_url,
+            audio_path=ep.audio_path,
+            artwork_path=ep.artwork_path,
+            duration_secs=ep.duration_secs,
+            pub_date=ep.pub_date,
+            updated_at=ep.updated_at,
+        )
+        for ep in page_rows
+    ]
+
+
+class DeleteEpisodeResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    files_removed: int = Field(ge=0)
+
+
+@router.delete(
+    "/episodes/{episode_id}",
+    response_model=DeleteEpisodeResponse,
+    dependencies=[Depends(require_admin)],
+)
+async def delete_episode(
+    episode_id: str,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> DeleteEpisodeResponse:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        episode = episodes_service.get_by_id(conn, episode_id)
+        if episode is None:
+            raise HTTPException(status_code=404, detail="episode not found")
+        conn.execute("DELETE FROM episodes WHERE id = ?", (episode_id,))
+        conn.commit()
+    finally:
+        conn.close()
+    out_root = media_dir(settings)
+    from pathlib import Path
+
+    files_removed = 0
+    for path_str in (episode.audio_path, episode.artwork_path):
+        if path_str and _remove_path(Path(path_str), root_guard=out_root):
+            files_removed += 1
+    if _remove_path(out_root / f"{episode_id}.vtt", root_guard=out_root):
+        files_removed += 1
+    return DeleteEpisodeResponse(id=episode_id, files_removed=files_removed)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,8 +6,10 @@ from fastapi import APIRouter
 
 from app.api.v1 import auth as auth_routes
 from app.api.v1 import corrections as corrections_routes
+from app.api.v1 import episodes as episodes_routes
 from app.api.v1 import prompt as prompt_routes
 from app.api.v1 import purge as purge_routes
+from app.api.v1 import settings as settings_routes
 from app.api.v1 import status as status_routes
 from app.api.v1 import submit as submit_routes
 
@@ -18,3 +20,5 @@ router.include_router(prompt_routes.router)
 router.include_router(corrections_routes.router)
 router.include_router(purge_routes.router)
 router.include_router(auth_routes.router)
+router.include_router(settings_routes.router)
+router.include_router(episodes_routes.router)

--- a/backend/app/api/v1/settings.py
+++ b/backend/app/api/v1/settings.py
@@ -1,0 +1,111 @@
+"""``GET/PUT /api/v1/settings`` -- operator-tunable runtime overrides.
+
+Only the allowlisted subset (``runtime_settings.ALLOWED_KEYS``) is exposed.
+Unknown keys on PUT return 400 with a list of accepted keys. Values are
+type-coerced against the ``Settings`` field annotations so a stored string
+``"450"`` for ``RETENTION_DAYS`` round-trips as an int.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from app.api.deps import require_admin
+from app.config import Settings, get_settings
+from app.core import database
+from app.services import runtime_settings
+
+router = APIRouter(tags=["settings"])
+
+
+class SettingsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    allowlist: list[str]
+    values: dict[str, Any]
+
+
+@router.get("/settings", response_model=SettingsResponse)
+async def get_settings_overrides(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> SettingsResponse:
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        stored = runtime_settings.get_all(conn)
+    finally:
+        conn.close()
+    coerced = {key: _coerce(key, value, settings) for key, value in stored.items()}
+    return SettingsResponse(
+        allowlist=sorted(runtime_settings.ALLOWED_KEYS),
+        values=coerced,
+    )
+
+
+@router.put(
+    "/settings",
+    response_model=SettingsResponse,
+    dependencies=[Depends(require_admin)],
+)
+async def put_settings_overrides(
+    payload: Annotated[dict[str, Any], Body()],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> SettingsResponse:
+    unknown = [k for k in payload if k not in runtime_settings.ALLOWED_KEYS]
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"unknown setting keys: {unknown}; allowed: {sorted(runtime_settings.ALLOWED_KEYS)}"
+            ),
+        )
+    conn = database.connect(database.db_path(settings.DATA_DIR))
+    try:
+        for key, value in payload.items():
+            runtime_settings.set_value(conn, key, value)
+        stored = runtime_settings.get_all(conn)
+    finally:
+        conn.close()
+    coerced = {key: _coerce(key, value, settings) for key, value in stored.items()}
+    return SettingsResponse(
+        allowlist=sorted(runtime_settings.ALLOWED_KEYS),
+        values=coerced,
+    )
+
+
+def _coerce(key: str, value: str, settings: Settings) -> Any:
+    """Coerce the stored string back to the declared field type.
+
+    Falls back to the raw string if the field isn't found (forward-compat
+    so a future config rename doesn't 500 an existing GET).
+    """
+
+    field = settings.__class__.model_fields.get(key)
+    if field is None:
+        return value
+    annotation = field.annotation
+    if annotation is bool:
+        try:
+            return bool(json.loads(value))
+        except (TypeError, ValueError):
+            return value.lower() in {"true", "1", "yes"}
+    if annotation is int:
+        try:
+            return int(json.loads(value))
+        except (TypeError, ValueError):
+            try:
+                return int(value)
+            except ValueError:
+                return value
+    if annotation is float:
+        try:
+            return float(json.loads(value))
+        except (TypeError, ValueError):
+            try:
+                return float(value)
+            except ValueError:
+                return value
+    return value

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -196,10 +196,27 @@ def _m003_auth_lockout(conn: sqlite3.Connection) -> None:
     )
 
 
+def _m004_runtime_settings(conn: sqlite3.Connection) -> None:
+    """Phase 10: operator-tunable settings that override env defaults at
+    request time. Keys are constrained to the Phase-10 allowlist; values
+    are stored as strings and coerced by the resolver."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS runtime_settings (
+            key         TEXT PRIMARY KEY,
+            value       TEXT NOT NULL,
+            updated_at  TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        )
+        """
+    )
+
+
 MIGRATIONS: list[tuple[str, Migration]] = [
     ("001_initial_schema", _m001_initial_schema),
     ("002_settings_kv", _m002_settings_kv),
     ("003_auth_lockout", _m003_auth_lockout),
+    ("004_runtime_settings", _m004_runtime_settings),
 ]
 
 

--- a/backend/app/services/runtime_settings.py
+++ b/backend/app/services/runtime_settings.py
@@ -1,0 +1,71 @@
+"""Operator-tunable settings that override env defaults at request time.
+
+Only an allowlisted subset of ``Settings`` fields is exposed -- the rest are
+infrastructure-level (DB path, secret keys) and would be footguns to flip
+without a restart. The resolver coerces stored strings back to the field's
+declared type via ``Settings.__class__.model_fields`` introspection.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+# Operator-tunable subset. Any field not in this set returns 400 on PUT and
+# is invisible on GET; cosmetic/runtime tuning lives here, secrets and
+# infrastructure paths do not.
+ALLOWED_KEYS: frozenset[str] = frozenset(
+    {
+        "FEED_TITLE",
+        "FEED_DESCRIPTION",
+        "FEED_AUTHOR",
+        "FEED_EMAIL",
+        "FEED_LANGUAGE",
+        "FEED_CATEGORY",
+        "FEED_EXPLICIT",
+        "FEED_ARTWORK_URL",
+        "RETENTION_DAYS",
+        "TTS_CHUNK_TARGET_WORDS",
+        "TTS_CHUNK_MAX_WORDS",
+        "TTS_CHUNK_SILENCE_MS",
+        "RSS_CACHE_MAX_AGE_SECONDS",
+        "MIN_CLEANUP_CHARS",
+        "MAX_PROMPT_LENGTH_BYTES",
+    }
+)
+
+
+def get_all(conn: sqlite3.Connection) -> dict[str, str]:
+    rows = conn.execute("SELECT key, value FROM runtime_settings").fetchall()
+    return {row["key"]: row["value"] for row in rows if row["key"] in ALLOWED_KEYS}
+
+
+def set_value(conn: sqlite3.Connection, key: str, value: Any) -> None:
+    if key not in ALLOWED_KEYS:
+        raise KeyError(f"{key} is not an operator-tunable setting")
+    serialized = _serialize(value)
+    conn.execute(
+        """
+        INSERT INTO runtime_settings (key, value, updated_at)
+        VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at
+        """,
+        (key, serialized),
+    )
+    conn.commit()
+
+
+def delete(conn: sqlite3.Connection, key: str) -> None:
+    conn.execute("DELETE FROM runtime_settings WHERE key = ?", (key,))
+    conn.commit()
+
+
+def _serialize(value: Any) -> str:
+    if isinstance(value, bool | int | float):
+        return json.dumps(value)
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)

--- a/backend/tests/test_api_episodes.py
+++ b/backend/tests/test_api_episodes.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.config import get_settings
+from app.core import database
+from app.core.paths import media_dir
+from app.main import create_app
+from app.services import episodes
+from fastapi.testclient import TestClient
+
+
+def _client(env: Path) -> TestClient:
+    database.run_migrations(env)
+    return TestClient(create_app())
+
+
+def _seed(env: Path, *, id_: str, with_files: bool = False) -> None:
+    database.run_migrations(env)
+    media = media_dir(get_settings())
+    media.mkdir(parents=True, exist_ok=True)
+    audio_path = str(media / f"{id_}.mp3")
+    jpg_path = str(media / f"{id_}.jpg")
+    if with_files:
+        (media / f"{id_}.mp3").write_bytes(b"FAKE")
+        (media / f"{id_}.jpg").write_bytes(b"FAKE")
+    conn = database.connect(database.db_path(env))
+    try:
+        episodes.upsert(
+            conn,
+            id=id_,
+            job_id=None,
+            original_url=f"https://example.test/{id_}",
+            title=id_,
+            author="A",
+            audio_path=audio_path,
+            artwork_path=jpg_path if with_files else None,
+            transcript_vtt="WEBVTT\n",
+            duration_secs=10,
+        )
+    finally:
+        conn.close()
+
+
+def test_list_episodes_returns_paginated_results_with_total_header(
+    env: Path,
+) -> None:
+    for n in range(3):
+        _seed(env, id_=f"ep{n}")
+    with _client(env) as client:
+        response = client.get("/api/v1/episodes?page=1&per_page=2")
+    assert response.status_code == 200
+    assert response.headers["X-Total-Count"] == "3"
+    assert len(response.json()) == 2
+
+
+def test_list_episodes_second_page(env: Path) -> None:
+    for n in range(5):
+        _seed(env, id_=f"ep{n}")
+    with _client(env) as client:
+        response = client.get("/api/v1/episodes?page=2&per_page=2")
+    assert response.headers["X-Total-Count"] == "5"
+    assert len(response.json()) == 2
+
+
+def test_delete_episode_removes_row_and_files(env: Path) -> None:
+    _seed(env, id_="del", with_files=True)
+    media = media_dir(get_settings())
+    assert (media / "del.mp3").exists()
+
+    with _client(env) as client:
+        response = client.delete("/api/v1/episodes/del")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "del"
+    assert body["files_removed"] >= 1
+    assert not (media / "del.mp3").exists()
+
+    conn = database.connect(database.db_path(env))
+    try:
+        assert episodes.get_by_id(conn, "del") is None
+    finally:
+        conn.close()
+
+
+def test_delete_episode_returns_404_when_missing(env: Path) -> None:
+    with _client(env) as client:
+        response = client.delete("/api/v1/episodes/unknown")
+    assert response.status_code == 404

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core import database
+from app.main import create_app
+from fastapi.testclient import TestClient
+
+
+def _client(env: Path) -> TestClient:
+    database.run_migrations(env)
+    return TestClient(create_app())
+
+
+def test_get_settings_returns_empty_values_initially(env: Path) -> None:
+    with _client(env) as client:
+        response = client.get("/api/v1/settings")
+    assert response.status_code == 200
+    body = response.json()
+    assert "RETENTION_DAYS" in body["allowlist"]
+    assert body["values"] == {}
+
+
+def test_put_settings_persists_and_coerces_types(env: Path) -> None:
+    with _client(env) as client:
+        response = client.put(
+            "/api/v1/settings",
+            json={
+                "RETENTION_DAYS": 30,
+                "FEED_TITLE": "My Custom Feed",
+                "FEED_EXPLICIT": True,
+            },
+        )
+    assert response.status_code == 200
+    values = response.json()["values"]
+    assert values["RETENTION_DAYS"] == 30
+    assert values["FEED_TITLE"] == "My Custom Feed"
+    assert values["FEED_EXPLICIT"] is True
+
+
+def test_put_settings_rejects_unknown_keys(env: Path) -> None:
+    with _client(env) as client:
+        response = client.put(
+            "/api/v1/settings",
+            json={"DATA_DIR": "/tmp/evil"},
+        )
+    assert response.status_code == 400
+    assert "DATA_DIR" in response.json()["error"]
+
+
+def test_put_then_get_round_trips(env: Path) -> None:
+    with _client(env) as client:
+        client.put("/api/v1/settings", json={"FEED_AUTHOR": "New Owner"})
+        response = client.get("/api/v1/settings")
+    assert response.json()["values"]["FEED_AUTHOR"] == "New Owner"

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -10,7 +10,12 @@ from app.core import database
 
 def test_run_migrations_creates_tables(tmp_path: Path) -> None:
     applied = database.run_migrations(tmp_path)
-    assert applied == ["001_initial_schema", "002_settings_kv", "003_auth_lockout"]
+    assert applied == [
+        "001_initial_schema",
+        "002_settings_kv",
+        "003_auth_lockout",
+        "004_runtime_settings",
+    ]
 
     conn = database.connect(database.db_path(tmp_path))
     try:
@@ -25,7 +30,12 @@ def test_run_migrations_creates_tables(tmp_path: Path) -> None:
 def test_second_run_is_a_noop(tmp_path: Path) -> None:
     first = database.run_migrations(tmp_path)
     second = database.run_migrations(tmp_path)
-    assert first == ["001_initial_schema", "002_settings_kv", "003_auth_lockout"]
+    assert first == [
+        "001_initial_schema",
+        "002_settings_kv",
+        "003_auth_lockout",
+        "004_runtime_settings",
+    ]
     assert second == []
 
 


### PR DESCRIPTION
## Summary

- `services/runtime_settings.py` + `api/v1/settings.py`: operator-tunable settings via the new `runtime_settings` table. Allowlist gates writes.
- `api/v1/episodes.py`: GET (paginated, X-Total-Count) + DELETE (file cleanup via the Phase-8 defense-in-depth helper).
- Migration `004_runtime_settings`.

## Test plan

- [x] `uv run pytest` — 295 passed (+8)
- [x] `uv run ruff check backend` — All checks passed