### PR TITLE
Codebase-wide review: security + correctness fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,3 +95,38 @@ ARTWORK_JPG_QUALITY=85
 ARTWORK_FETCH_TIMEOUT_SECONDS=15
 ARTWORK_MIN_SOURCE_PX=600
 ARTWORK_MAX_DOWNLOAD_BYTES=26214400
+
+# ---------- Auth (REQUIRED for any public-internet deployment) ----------
+# When AUTH_ENABLED=false (the default) the admin endpoints accept
+# unauthenticated requests. This is the convenience mode for a
+# single-operator localhost install. Flip to true the moment the app is
+# reachable from anything other than your laptop.
+AUTH_ENABLED=false
+
+# Required when AUTH_ENABLED=true. Single admin user.
+ADMIN_USERNAME=admin
+
+# Required when AUTH_ENABLED=true. Generate with:
+#   uv run python -c "from app.services import auth; print(auth.hash_password('YOUR-PASSWORD'))"
+ADMIN_PASSWORD_HASH=
+
+# Required when AUTH_ENABLED=true. Generate with:
+#   uv run python -c "import secrets; print(secrets.token_urlsafe(64))"
+SESSION_SECRET_KEY=
+
+# Set to true once you've fronted the app with HTTPS. Default false so
+# localhost http:// works.
+SESSION_COOKIE_SECURE=false
+
+# Session cookie lifetime. Default is 14 days.
+SESSION_COOKIE_MAX_AGE_SECONDS=1209600
+
+# Lockout policy. 5 failed attempts opens a 15-minute window during which
+# subsequent attempts return 423 Locked. Tune for your threat model.
+LOCKOUT_MAX_FAILED_ATTEMPTS=5
+LOCKOUT_WINDOW_SECONDS=900
+
+# Per-IP rate limit on /api/v1/auth/login. The slowapi limiter currently
+# uses a hardcoded decorator value; the env var is advisory until the
+# wiring is refactored to pull the limit at request time.
+LOGIN_RATE_LIMIT=10/minute

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Security + correctness (codebase-wide review)
+
+Multi-agent /simplify + /code-review sweep over the full backend (49 service modules + 38 test files), plus a background security finding (missing auth on `GET /api/v1/settings`).
+
+**Security:**
+
+- **Missing auth on read-only admin endpoints**: `GET /api/v1/prompt`, `GET /api/v1/corrections`, `GET /api/v1/settings` had no `require_admin` dependency, so when `AUTH_ENABLED=true` they still leaked operator config. Added `dependencies=[Depends(require_admin)]` to all three.
+- **Missing auth on `POST /api/v1/submit`**: anyone could enqueue jobs and burn LLM / TTS quota. Added `require_admin`.
+- **Login timing oracle**: `verify_credentials` short-circuited bcrypt for unknown usernames so response time revealed whether a username existed (~50-100ms vs. ~0ms). Now always runs bcrypt against either the real `ADMIN_PASSWORD_HASH` or a precomputed `_DUMMY_HASH`; username comparison uses `hmac.compare_digest`.
+- **Lockout counter race**: previous `_register_failed_attempt` was a SELECT-then-UPSERT pair; concurrent failed logins under `WEB_WORKERS=2` could both read N and both write N+1, defeating `LOCKOUT_MAX_FAILED_ATTEMPTS`. Replaced with `INSERT ... ON CONFLICT DO UPDATE SET failed_attempts = failed_attempts + 1, lockout_until = CASE WHEN ... THEN ... ELSE NULL END` so the increment + threshold check happen inside one engine-serialized statement.
+- **CSRF on safe methods**: `require_admin` enforced the CSRF header on every method including `GET`, which 403'd a SPA between session-cookie load and CSRF-cookie read. Now skips for `GET`/`HEAD`/`OPTIONS`; session check still applies.
+- **`/health/ready` exception leak**: failure path returned `f"error: {exc}"` in the response body, exposing `sqlite3.OperationalError` text including the absolute `DATA_DIR` path. Now returns a generic `"error"`; the full exception stays in the WARN log only.
+- **`POST /api/v1/submit.url` length cap**: added `max_length=2048`.
+- **`tts-wrapper` `GenerateRequest.text` length cap**: added `max_length=4000` so an oversized payload can't hold the `asyncio.Lock` for 120s and starve every other `/generate` call.
+- **`.env.example` had no auth block**: operators copying it deployed with `AUTH_ENABLED=false` and zero signal to flip it. Added a `# ---- Auth (REQUIRED for any public-internet deployment) ----` section with placeholders, generation commands, and explanatory comments.
+
+**Cleanup:**
+
+- Shared `retention.MAX_OLDER_THAN_DAYS` between the service guard and the purge endpoint's `Query(..., le=...)` constraint.
+- Lifted three inline imports in `main.py` (`secrets`, `_LOGIN_LIMITER`, `JSONResponse`) to the module top per `CLAUDE.md`.
+- Replaced the hand-built 429 envelope in `_attach_rate_limiter` with `errors.envelope(status=429, error="rate limit exceeded")` — the canonical helper every other 4xx/5xx route uses.
+
+**Tests (16 new, 317 total):** parametrized tables in `test_api_auth.py` assert every admin route returns 401 without a session when `AUTH_ENABLED=true`, mutating routes return 403 without `X-CSRF-Token`, and `GET` is allowed with session + no CSRF (safe-methods exemption). A typo on any future `dependencies=[Depends(require_admin)]` declaration is caught immediately.
+
+**Deferred (real findings, deserve their own PR):**
+
+- Runtime settings (`PUT /api/v1/settings`) persists overrides but no production service reads them back. The Phase 10 docstring promised a "code default → env var → DB" resolution chain that doesn't yet exist.
+- `database.connect/close` try/finally repeats 20 times across 12 modules — would benefit from a `core/database.connection(settings)` context manager.
+- ISO-timestamp `Z`-suffix parsing repeats in `feed.py`, `auth.py`, and `api/rss.py` — promote to `core/timestamps.parse_iso`.
+- `list_episodes` / `list_jobs` use Python slice rather than SQL `LIMIT`/`OFFSET` + `COUNT(*)`.
+- DNS-rebinding TOCTOU in the artwork SSRF guard.
+- Phase 11 (Web UI) remains deferred.
+
 ### Security (Pre-emptive CodeQL hardening)
 
 - `.github/workflows/codeql.yml`: GitHub CodeQL with the `security-and-quality` query pack. Runs on every PR + push + a weekly schedule. Top-level `permissions: {}` with the analysis job re-narrowing to `security-events: write` + read-only repo access (least privilege).

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -32,6 +32,11 @@ def require_admin(
     user = request.session.get(SESSION_KEY_USER)
     if not user:
         raise HTTPException(status_code=401, detail="login required")
+    # Skip CSRF on safe methods. The header is a write-side defense; a
+    # cookie-authenticated GET in a fresh tab (before the UI has loaded the
+    # cookie into memory) should warm the cache, not 403.
+    if request.method in {"GET", "HEAD", "OPTIONS"}:
+        return
     if not csrf.verify_token(
         request.headers.get(csrf.CSRF_HEADER_NAME),
         request.cookies.get(csrf.CSRF_COOKIE_NAME),

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -48,7 +48,11 @@ def health_ready(request: Request, response: Response) -> dict[str, Any]:
             extra={"event": "health_db_error", "error": str(exc)},
             exc_info=True,
         )
-        checks["db"] = f"error: {exc}"
+        # Generic ``"error"`` rather than the raw exception string so
+        # /health/ready (unauthenticated, conventionally polled by public
+        # load balancers) doesn't leak DATA_DIR paths or errno text. The
+        # full exception is in the WARN log above.
+        checks["db"] = "error"
 
     started_at = getattr(request.app.state, "started_at", time.monotonic())
     body: dict[str, Any] = {

--- a/backend/app/api/v1/corrections.py
+++ b/backend/app/api/v1/corrections.py
@@ -18,7 +18,11 @@ def _corrections_path() -> Path:
     return Path(__file__).parent.parent.parent / "corrections" / "pronunciation.json"
 
 
-@router.get("/corrections", summary="Read the pronunciation dictionary")
+@router.get(
+    "/corrections",
+    summary="Read the pronunciation dictionary",
+    dependencies=[Depends(require_admin)],
+)
 def read_corrections() -> dict[str, str]:
     try:
         return corrections_service.load(_corrections_path())

--- a/backend/app/api/v1/prompt.py
+++ b/backend/app/api/v1/prompt.py
@@ -34,7 +34,12 @@ class PromptBody(BaseModel):
         return value
 
 
-@router.get("/prompt", response_model=PromptBody, summary="Read the cleanup prompt")
+@router.get(
+    "/prompt",
+    response_model=PromptBody,
+    summary="Read the cleanup prompt",
+    dependencies=[Depends(require_admin)],
+)
 def read_prompt() -> PromptBody:
     path = _prompt_path()
     try:

--- a/backend/app/api/v1/purge.py
+++ b/backend/app/api/v1/purge.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.api.deps import require_admin
 from app.config import Settings, get_settings
 from app.services import retention
+from app.services.retention import MAX_OLDER_THAN_DAYS
 
 router = APIRouter(tags=["maintenance"])
 
@@ -44,7 +45,7 @@ async def post_purge(
         Query(
             description="Purge episodes older than N days. 0 wipes everything.",
             ge=0,
-            le=100_000,
+            le=MAX_OLDER_THAN_DAYS,
         ),
     ] = 0,
 ) -> PurgeResponse:

--- a/backend/app/api/v1/settings.py
+++ b/backend/app/api/v1/settings.py
@@ -29,7 +29,11 @@ class SettingsResponse(BaseModel):
     values: dict[str, Any]
 
 
-@router.get("/settings", response_model=SettingsResponse)
+@router.get(
+    "/settings",
+    response_model=SettingsResponse,
+    dependencies=[Depends(require_admin)],
+)
 async def get_settings_overrides(
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> SettingsResponse:

--- a/backend/app/api/v1/submit.py
+++ b/backend/app/api/v1/submit.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
 
+from app.api.deps import require_admin
 from app.config import Settings, get_settings
 from app.core import database
 from app.services import jobs
@@ -20,6 +21,10 @@ class SubmitRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     url: str = Field(
+        # 2048 covers every legitimate article URL we've seen in practice
+        # and caps a pathological-URL DoS at a reasonable size.
+        max_length=2048,
+        min_length=1,
         description="HTTP/HTTPS URL of the article to ingest.",
     )
     reprocess: bool = Field(
@@ -56,6 +61,7 @@ class SubmitResponse(BaseModel):
     status_code=201,
     response_model=SubmitResponse,
     summary="Submit an article URL for processing",
+    dependencies=[Depends(require_admin)],
 )
 def submit(
     body: SubmitRequest,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -12,9 +13,11 @@ from slowapi.errors import RateLimitExceeded
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.api import errors as error_handlers
+from app.api.errors import envelope
 from app.api.health import router as health_router
 from app.api.media import router as media_router
 from app.api.rss import router as rss_router
+from app.api.v1.auth import _LOGIN_LIMITER
 from app.api.v1.router import router as v1_router
 from app.config import Settings, get_settings
 from app.startup import bootstrap
@@ -56,12 +59,13 @@ def _attach_session_middleware(app: FastAPI, settings: Settings) -> None:
     # off, in which case both reads return None). The ephemeral key means
     # the cookie is unforgeable across restarts but no operator state
     # depends on it persisting.
+    # ``_validate_auth`` refuses to start with AUTH_ENABLED=true and no
+    # SESSION_SECRET_KEY, so the random-key path is only reached when auth
+    # is off -- the session contents are not security-relevant in that mode.
     if settings.AUTH_ENABLED and settings.SESSION_SECRET_KEY:
         secret_key = settings.SESSION_SECRET_KEY
     else:
-        import secrets as _secrets
-
-        secret_key = _secrets.token_urlsafe(64)
+        secret_key = secrets.token_urlsafe(64)
     app.add_middleware(
         SessionMiddleware,
         secret_key=secret_key,
@@ -74,20 +78,13 @@ def _attach_session_middleware(app: FastAPI, settings: Settings) -> None:
 
 def _attach_rate_limiter(app: FastAPI, settings: Settings) -> None:
     # The auth router instantiates its own module-level limiter so the
-    # decorator can resolve at import time; we hook the same instance into
-    # ``app.state.limiter`` so slowapi's request middleware can find it.
-    from app.api.v1.auth import _LOGIN_LIMITER
-
+    # decorator can resolve at import time; hook the same instance into
+    # ``app.state.limiter`` so slowapi's request middleware finds it.
     app.state.limiter = _LOGIN_LIMITER
 
     @app.exception_handler(RateLimitExceeded)
     async def _rate_limit_handler(_request, exc):
-        from fastapi.responses import JSONResponse
-
-        return JSONResponse(
-            status_code=429,
-            content={"error": "rate limit exceeded", "status": 429},
-        )
+        return envelope(status=429, error="rate limit exceeded")
 
     _ = settings  # LOGIN_RATE_LIMIT is currently advisory; see auth.py
 

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -19,6 +19,7 @@ verifier always re-reads it (no in-memory cache) so a manual
 
 from __future__ import annotations
 
+import hmac
 import logging
 import sqlite3
 from dataclasses import dataclass
@@ -27,6 +28,13 @@ from datetime import UTC, datetime, timedelta
 import bcrypt
 
 from app.config import Settings
+
+# Precomputed valid-shape bcrypt hash whose checkpw of any input is False.
+# Verify_credentials runs bcrypt even on unknown usernames against this hash
+# so the wall-clock cost of a login attempt is constant regardless of
+# whether the username exists -- closes the timing oracle described by the
+# code-review pass.
+_DUMMY_HASH = "$2b$12$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.123"
 
 logger = logging.getLogger("app.services.auth")
 
@@ -97,7 +105,15 @@ def verify_credentials(
         raise LockedOutError(state.locked_until)
 
     expected_user = settings.ADMIN_USERNAME.strip().lower()
-    if identifier != expected_user or not _verify_password(password, settings.ADMIN_PASSWORD_HASH):
+    # Always run bcrypt -- against the dummy hash for an unknown username --
+    # so the response time doesn't reveal whether the username matched.
+    # ``hmac.compare_digest`` is constant-time over the strings.
+    user_ok = hmac.compare_digest(identifier, expected_user)
+    pw_ok = _verify_password(
+        password,
+        settings.ADMIN_PASSWORD_HASH if user_ok else _DUMMY_HASH,
+    )
+    if not (user_ok and pw_ok):
         _register_failed_attempt(conn, identifier, settings)
         raise InvalidCredentialsError("invalid username or password")
 
@@ -122,35 +138,52 @@ def _get_lockout(conn: sqlite3.Connection, identifier: str) -> LockoutState | No
 
 
 def _register_failed_attempt(conn: sqlite3.Connection, identifier: str, settings: Settings) -> None:
+    """Atomically bump the failed-attempt counter and arm the lockout window.
+
+    The previous implementation read the row in Python and wrote the new
+    value back, which raced under WEB_WORKERS=2 (two concurrent failed
+    logins could both read N and write N+1, defeating the threshold). The
+    single SQL statement below does the increment + lockout decision inside
+    the engine so SQLite's per-row write lock makes the operation
+    serializable.
+    """
+
     now = datetime.now(UTC)
     now_iso = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    state = _get_lockout(conn, identifier)
-    failed = (state.failed_attempts if state else 0) + 1
-    locked_until: str | None = None
-    if failed >= settings.LOCKOUT_MAX_FAILED_ATTEMPTS:
-        locked_until = (now + timedelta(seconds=settings.LOCKOUT_WINDOW_SECONDS)).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+    locked_until_iso = (now + timedelta(seconds=settings.LOCKOUT_WINDOW_SECONDS)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    threshold = settings.LOCKOUT_MAX_FAILED_ATTEMPTS
     conn.execute(
         """
-        INSERT INTO auth_lockout (identifier, failed_attempts, last_attempt_at, lockout_until)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO auth_lockout (
+            identifier, failed_attempts, last_attempt_at, lockout_until
+        )
+        VALUES (?, 1, ?, NULL)
         ON CONFLICT(identifier) DO UPDATE SET
-            failed_attempts = excluded.failed_attempts,
+            failed_attempts = failed_attempts + 1,
             last_attempt_at = excluded.last_attempt_at,
-            lockout_until   = excluded.lockout_until
+            lockout_until = CASE
+                WHEN failed_attempts + 1 >= ?
+                THEN ?
+                ELSE NULL
+            END
         """,
-        (identifier, failed, now_iso, locked_until),
+        (identifier, now_iso, threshold, locked_until_iso),
     )
     conn.commit()
-    if locked_until:
+    row = conn.execute(
+        "SELECT failed_attempts, lockout_until FROM auth_lockout WHERE identifier = ?",
+        (identifier,),
+    ).fetchone()
+    if row is not None and row["lockout_until"] is not None:
         logger.warning(
             "Lockout triggered",
             extra={
                 "event": "auth_lockout_triggered",
                 "identifier": identifier,
-                "failed_attempts": failed,
-                "locked_until": locked_until,
+                "failed_attempts": row["failed_attempts"],
+                "locked_until": row["lockout_until"],
             },
         )
 

--- a/backend/app/services/retention.py
+++ b/backend/app/services/retention.py
@@ -33,8 +33,10 @@ class PurgeResult:
 # Upper bound on the day-count parameter; Python's datetime only spans years
 # 1..9999, so ``datetime.now() - timedelta(days=N)`` overflows past roughly
 # 2.9M days. Cap at 100k days (~273 years) which is well past any plausible
-# retention window and still safely inside the datetime range.
-_MAX_OLDER_THAN_DAYS = 100_000
+# retention window and still safely inside the datetime range. The purge
+# endpoint mirrors this via ``le=MAX_OLDER_THAN_DAYS`` on the Query.
+MAX_OLDER_THAN_DAYS = 100_000
+_MAX_OLDER_THAN_DAYS = MAX_OLDER_THAN_DAYS  # backwards-compat alias
 
 
 def purge_older_than(

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -143,6 +143,62 @@ def test_mutating_endpoint_succeeds_with_session_and_csrf(auth_env) -> None:
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "method,url,body",
+    [
+        ("GET", "/api/v1/prompt", None),
+        ("GET", "/api/v1/corrections", None),
+        ("GET", "/api/v1/settings", None),
+        ("GET", "/api/v1/episodes", None),
+        ("GET", "/api/v1/jobs", None),
+        ("PUT", "/api/v1/settings", {"FEED_TITLE": "x"}),
+        ("PUT", "/api/v1/prompt", {"prompt": "x" * 200}),
+        ("DELETE", "/api/v1/episodes/abc123", None),
+        ("POST", "/api/v1/submit", {"url": "https://example.test/x"}),
+        ("POST", "/api/v1/purge?confirm=true", None),
+    ],
+)
+def test_admin_routes_require_session_when_auth_enabled(auth_env, method, url, body) -> None:
+    """Any route under ``dependencies=[Depends(require_admin)]`` must 401
+    without a session. Parametrized so a typo on a single route declaration
+    is caught."""
+
+    with _client() as client:
+        response = client.request(method, url, json=body)
+    assert response.status_code == 401, f"{method} {url} leaked without a session"
+
+
+@pytest.mark.parametrize(
+    "method,url,body",
+    [
+        ("PUT", "/api/v1/settings", {"FEED_TITLE": "x"}),
+        ("PUT", "/api/v1/prompt", {"prompt": "x" * 200}),
+        ("DELETE", "/api/v1/episodes/abc123", None),
+        ("POST", "/api/v1/submit", {"url": "https://example.test/x"}),
+        ("POST", "/api/v1/purge?confirm=true", None),
+    ],
+)
+def test_admin_mutating_routes_require_csrf_after_login(auth_env, method, url, body) -> None:
+    """A logged-in client must echo the CSRF header on mutating calls.
+    GETs are exempt per the deps.require_admin contract."""
+
+    with _client() as client:
+        client.post("/api/v1/auth/login", json=auth_env)
+        response = client.request(method, url, json=body)
+    assert response.status_code == 403, f"{method} {url} accepted without X-CSRF-Token"
+
+
+def test_admin_get_route_is_allowed_with_session_no_csrf(auth_env) -> None:
+    """GET must NOT require the CSRF header even with auth on -- a SPA
+    warming the cache shouldn't 403 between session-cookie load and
+    CSRF-cookie read."""
+
+    with _client() as client:
+        client.post("/api/v1/auth/login", json=auth_env)
+        response = client.get("/api/v1/prompt")
+    assert response.status_code == 200
+
+
 def test_mutating_endpoint_unrestricted_when_auth_disabled(
     env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tts-wrapper/main.py
+++ b/tts-wrapper/main.py
@@ -38,7 +38,10 @@ _REQUEST_INFERENCE_TIMEOUT_SECONDS = float(os.environ.get("TTS_REQUEST_TIMEOUT_S
 
 class GenerateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    text: str = Field(min_length=1)
+    # Cap matches the backend chunker's TTS_CHUNK_MAX_CHARS ceiling plus a
+    # small headroom. An oversized payload would hold the asyncio.Lock for
+    # the inference window and starve every other /generate call.
+    text: str = Field(min_length=1, max_length=4000)
     # Path-safety: episode_id ends up in a filename; reject anything that
     # could escape data_dir/media. Backend uses MD5[:12] hex by default but
     # accept a slightly broader alphabet for hand-curated cases.


### PR DESCRIPTION
## Summary

Multi-agent /simplify + /code-review sweep over the full backend (49 service modules + 38 tests). The background security review also flagged GET /api/v1/settings missing auth, which is one of the fixes here.

**Security**

- Added \`require_admin\` to GET /api/v1/{prompt,corrections,settings} and POST /api/v1/submit (were leaking operator config / accepting jobs even when AUTH_ENABLED=true).
- Fixed login timing oracle: always run bcrypt against either the real hash or a precomputed _DUMMY_HASH; username compared via hmac.compare_digest.
- Fixed lockout counter race: SELECT-then-UPSERT replaced with a single INSERT ... ON CONFLICT DO UPDATE that increments + arms the lockout in one engine-serialized statement.
- CSRF on GET/HEAD/OPTIONS skipped (was 403ing SPAs between session cookie load and CSRF cookie read).
- /health/ready no longer leaks raw sqlite3.OperationalError text including DATA_DIR.
- POST /api/v1/submit.url length cap (max_length=2048).
- tts-wrapper GenerateRequest.text length cap (max_length=4000).
- .env.example now has a documented Auth block with generation commands.

**Cleanup**

- Shared \`retention.MAX_OLDER_THAN_DAYS\` between service + endpoint.
- Lifted three inline imports in main.py per CLAUDE.md.
- Replaced hand-built 429 envelope with errors.envelope().

## Test plan

- [x] \`uv run pytest\` — 317 passed (+16 parametrized auth-gating cases)
- [x] \`uv run ruff check backend tts-wrapper\` — All checks passed
- [x] CodeQL workflow will run automatically on this PR (the workflow was added in the previous PR).

## Deferred (real findings, separate PRs)

- Runtime settings end-to-end wiring (PUT persists overrides but no service reads them back).
- DB-connection context manager helper.
- Promote ISO-timestamp parsing to core/timestamps.
- SQL LIMIT/OFFSET pagination for list_episodes / list_jobs.
- DNS-rebinding TOCTOU in artwork SSRF guard.
- Phase 11 Web UI.