### PR TITLE
Close phase 13 gap-closure deliverables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Gap-closure pass (`chore/close-real-gaps`)
+
+Plan-completion audit found 5 missing deliverables and 7 partially-shipped items left from earlier phases. This pass closes them and folds in the simplify + code-review fix lists.
+
+**Phase 13 deliverables newly shipped:**
+
+- `backend/app/api/v1/reference.py`: `GET /reference/preview`, `POST /reference/test`, `POST /reference/commit` for operator voice management. Streaming upload cap, `wave.open` validation (3-60 s, <= 5 MB), `asyncio.Lock`-serialised stage/restore for `/test`, atomic write + wrapper `/reload` for `/commit`.
+- `backend/app/reference/README.md`: voice clip spec table, sourcing playbook, ffprobe verification, CPML licence note.
+- `openapi.yaml`: generated via `uv run python scripts/dump_openapi.py`.
+- `backend/app/api/health.py`: `/health/ready` now aggregates DB + ffmpeg + TTS + Firecrawl + LLM probes. Sequential probes parallelised via `asyncio.gather(return_exceptions=True)` so one stuck upstream can't add its budget to the others. ffmpeg banner cached only on success so a late PATH fix becomes visible.
+
+**Web UI completed:**
+
+- `frontend/src/routes/Settings.tsx`: 5 grouped sections (Feed / TTS / Cleanup / Retention / RSS), prompt editor (PUT `/api/v1/prompt`), corrections table (PUT `/api/v1/corrections`), reference voice widget (preview/test/commit), system-info block.
+- `frontend/src/routes/Feed.tsx`: mobile pull-to-refresh on the episode list.
+
+**Correctness fixes from /simplify and /code-review:**
+
+- CSRF: `frontend/src/lib/api.ts` `readCsrf` exported; `Settings.tsx` now uses it instead of inline `split("=")[1]` parsing that truncated base64-padded tokens.
+- React state: `PromptEditor` and `CorrectionsTable` seed via lazy `useState` initializer + gate on `data !== undefined` at the parent so in-progress edits survive React Query refetches.
+- `CorrectionsTable` rows now have stable IDs (no more React array-index keys); focus and IME composition no longer jump when rows are deleted.
+- `URL.revokeObjectURL` cleanup added to the reference audition pane.
+- `reference.py`: removed `except BaseException` (was swallowing `CancelledError`); narrowed to `Exception`. Suppressed `/reload` errors now logged at WARN. Wrapper-supplied `wav_path` validated against `DATA_DIR` to prevent arbitrary local read.
+- `reference.py` `/test` no longer leaves the candidate as the live voice when no prior reference existed (`backup is None` branch now unlinks instead of preserving).
+- `_validate_wav` switched from `tempfile.NamedTemporaryFile` to `io.BytesIO`; saves a disk write per call.
+- `_read_upload_capped` rejects oversized uploads mid-stream instead of buffering the whole body first.
+- `Settings.tsx` reference widget: `postForm` wraps `fetch` with try/catch so transport errors surface as a user-visible message; file-input `onChange` clears stale audition.
+- `health.py` no-URL LLM path returns `"skipped"` via `_probe_http`'s existing empty-base branch; `_noop_skipped` helper removed.
+
+**Lint/imports cleanup:**
+
+- Inline `import subprocess` / `import httpx` / `from contextlib import contextmanager` lifted to module top in `health.py` and `reference.py` per `CLAUDE.md`.
+- `pyproject.toml`: added `python-multipart` for FastAPI `UploadFile`/`Form`.
+
+**Tests:** 6 new in `test_api_reference.py` (preview 404, preview serves, commit atomic swap + reload, reject too-short / oversized / non-WAV). 332 backend tests pass; ruff clean.
+
 ### Security + correctness (codebase-wide review)
 
 Multi-agent /simplify + /code-review sweep over the full backend (49 service modules + 38 test files), plus a background security finding (missing auth on `GET /api/v1/settings`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm run build
 FROM ghcr.io/astral-sh/uv:0.11.17 AS uv
 
 # ---- Stage 3: Python runtime ----
-FROM python:3.13-slim AS runtime
+FROM python:3.14-slim AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -1,36 +1,156 @@
-# Audicle Planning Package
+# Audicle
 
-Planning and design artifacts for **Audicle** (audio + article), a self-hosted service that turns article URLs into a Podcasting 2.0 feed.
+Self-hosted Podcasting 2.0 service that turns saved articles into a personal podcast feed.
 
-Tagline: *Your reading list, as a podcast you own.*
+Paste a URL, wait a few minutes, get an episode with cloned-voice narration, artwork, and a WebVTT transcript. Subscribe in Pocket Casts, Overcast, or Apple Podcasts the same way you'd subscribe to anyone else's show.
 
-Repo: https://github.com/ttlequals0/Audicle
+Tagline: *your reading list, as a podcast you own.*
 
-## Contents
+## Why
 
-| File | What it is |
-|------|------------|
-| `build-plan.md` | The full build plan. Architecture, data model, pipeline, API conventions, auth, UI, RSS, audio, deployment, and a 13-phase build order. Start here. |
-| `ui-mockup.html` | Mobile-first, three-tab UI mockup (Home / Feed / Settings). Open in a browser; tabs are clickable. Reflects the locked design system (Satoshi + JetBrains Mono, dark green-on-black). |
-| `logo-spec.md` | Logo construction reference: the "A" mark with five-bar waveform crossbar. |
-| `branding/` | Canonical brand assets and design tokens. Single source of truth for backend and frontend. |
+I read too much, drive too much, and the existing "article to audio" tools either lock the audio behind their app, charge per minute, or use voices that sound like the airport PA. I wanted something that:
 
-## branding/
+- runs on my own GPU box
+- produces a real podcast feed any podcatcher can subscribe to
+- uses my own voice (or any voice I have rights to)
+- keeps the source URL list private
 
-| File | Purpose |
-|------|---------|
-| `README.md` | Palette, typography, usage, trademark note. |
-| `tokens.json` | Design tokens (color, typography, radius) in machine-readable form. |
-| `tokens.css` | Same tokens as CSS custom properties for the frontend. |
-| `mark.svg`, `mark-mono.svg` | Icon only. |
-| `wordmark.svg`, `wordmark-mono.svg` | Mark + "audicle" text. |
-| `podcast-artwork.svg`, `podcast-artwork-3000.png`, `podcast-artwork-1400.png` | Podcast cover art (Apple sizes). |
-| `favicon.svg`, `favicon-32.png`, `favicon-16.png` | Favicons. |
+That's what this is. If you don't have a GPU, it'll run on CPU too, just 5-10x slower per chunk.
+
+## What's in the repo
+
+```
+backend/        FastAPI app, SQLite, the job pipeline
+tts-wrapper/    XTTS-v2 model server (separate container for GPU isolation)
+frontend/       React + Tailwind operator UI
+data/           runtime artifacts (gitignored: SQLite, MP3, JPG, VTT)
+docker-compose.yml
+build-plan.md   the design document the implementation tracks against
+```
+
+## Quickstart
+
+You need Docker, docker-compose, a `voice.wav` file (3-60s of clean speech), and an LLM key.
+
+```bash
+git clone https://github.com/ttlequals0/Audicle && cd Audicle
+cp .env.example .env
+# edit .env, see "Required env vars" below
+cp /path/to/your/voice.wav backend/app/reference/voice.wav
+docker compose up -d
+```
+
+The web UI is at `http://localhost:8000/`. The RSS feed is `http://localhost:8000/rss/rss.xml` -- paste that into any podcatcher.
+
+If you don't have a CUDA GPU, override the wrapper to use CPU:
+
+```bash
+TTS_DEVICE=cpu docker compose up -d
+```
+
+First-run model download is ~2 GB and lives in a named volume (`hf_cache`).
+
+## Required env vars
+
+| Variable | What it is | Example |
+|---|---|---|
+| `BASE_URL` | Public-facing URL for the feed and media | `https://podcast.example.com` |
+| `FEED_TITLE` | Podcast title | `Drew's reading list` |
+| `FEED_AUTHOR` | Author / itunes:author | `Drew K.` |
+| `FEED_EMAIL` | Owner email (required by Apple) | `you@example.com` |
+| `FEED_CATEGORY` | iTunes category (see list below) | `Technology` |
+| `FEED_LANGUAGE` | RFC 5646 tag | `en-US` |
+| `FIRECRAWL_URL` | Self-hosted Firecrawl base URL | `http://firecrawl:3002` |
+| `LLM_PROVIDER` | `openai-compatible` or `anthropic` | `openai-compatible` |
+| `OPENAI_BASE_URL` | for openai-compatible only | `http://llm:8080/v1` |
+| `OPENAI_API_KEY` | for openai-compatible | `sk-...` |
+| `ANTHROPIC_API_KEY` | for anthropic | `sk-ant-...` |
+| `ADMIN_USERNAME` / `ADMIN_PASSWORD` | Admin UI auth (if `AUTH_ENABLED=true`) | -- |
+| `SESSION_SECRET_KEY` | 32+ random bytes for session signing | `openssl rand -hex 32` |
+
+Full list with defaults lives in `.env.example`. The runtime allowlist (what's editable from the UI without a restart) is enforced in `backend/app/services/runtime_settings.py`.
+
+## Valid iTunes categories
+
+Apple's parser rejects anything not on its list. The current ones (from Apple's RSS spec, May 2026):
+
+```
+Arts, Business, Comedy, Education, Fiction, Government, History,
+Health & Fitness, Kids & Family, Leisure, Music, News, Religion & Spirituality,
+Science, Society & Culture, Sports, Technology, True Crime, TV & Film
+```
+
+Subcategories aren't currently surfaced in the UI -- set the top-level category and call it done. If Apple Podcasts shows your feed as "Unknown" after submission, it's almost always a category typo.
+
+## Reference voice
+
+The wrapper conditions on a single short clip you supply. Recommended spec is mono, 24 kHz, 8-12 seconds, around 250 kB to 1 MB. Hard limits enforced by `POST /api/v1/reference/commit` are 3-60 s and <= 5 MB. See `backend/app/reference/README.md` for the sourcing playbook (record yourself, reuse a creative-commons clip, or synthesize one).
+
+Two notes the docs page doesn't repeat:
+
+- The audio quality of the output is mostly determined by the quality of this clip. Cleaning up the source clip (noise reduction, leveling) buys you more than tweaking the TTS knobs.
+- The Settings page in the UI lets you upload a candidate, audition it via `POST /api/v1/reference/test`, and commit only if you like it. Skip the audition at your peril.
+
+## Licensing notes
+
+The application code is MIT. Two things downstream of it are not:
+
+- **XTTS-v2 weights** ship under the Coqui Public Model Licence 1.0.0 (CPML). It is non-commercial. Personal self-hosted use is fine; selling the generated audio isn't. If you need a commercial pipeline, swap the wrapper for a different TTS model that's licensed for it. The wrapper interface (`POST /generate` + `POST /reload`) is small enough that this is straightforward.
+- **Coqui TTS on Python 3.13**: the upstream `coqui-tts` PyPI package as of 2026-05 declares `python_requires<3.13`. The wrapper Dockerfile pins Python 3.11 for that reason. If you try to run the wrapper on a 3.13 host outside the container, install from the `idiap/coqui-ai-TTS` fork instead -- that one has the version constraint lifted.
+
+The Audicle name and logo are reserved; see `branding/README.md`.
+
+## Architecture
+
+```
+URL --> extract (Firecrawl) --> cleanup (LLM) --> corrections (regex)
+                                                       |
+                                                       v
+                                              chunk + TTS (XTTS-v2)
+                                                       |
+                                                       v
+                                       audio (ffmpeg) + artwork + VTT
+                                                       |
+                                                       v
+                                          finalize (write DB + RSS)
+```
+
+Two containers: the backend (FastAPI + SQLite) and the TTS wrapper (separate so GPU memory stays isolated and the model only reloads when the voice changes). They share a `/data` volume so the backend can read what the wrapper produces.
+
+There's no message queue. SQLite handles the work queue via a single locked row update -- fine for one or two operators, not the right shape if you ever want to fan out across hosts.
+
+## Operating
+
+- `/health/live` is a flat liveness probe.
+- `/health/ready` aggregates DB, ffmpeg, TTS wrapper, Firecrawl, and (optionally) LLM probes. Returns 503 if any check fails.
+- `POST /api/v1/purge` removes episodes older than the retention window. Confirmation required.
+- Background retention sweep runs from the worker on a fixed cadence -- configurable via `RETENTION_DAYS`.
+- Default rate limits are conservative; the `slowapi` middleware wiring lives in `backend/app/main.py`.
+
+If something's broken, start with `/health/ready` -- it tells you which dependency is unhappy. Logs live where docker put them (`docker compose logs app` / `docker compose logs tts-wrapper`).
+
+## Development
+
+Backend:
+
+```bash
+uv sync
+uv run pytest                              # 332 tests, ~30s
+uv run uvicorn app.main:create_app --factory --reload --app-dir backend
+```
+
+Frontend:
+
+```bash
+cd frontend && npm install && npm run dev   # Vite, hot reload
+```
+
+There's an OpenAPI dump at `openapi.yaml`; regenerate via `uv run python scripts/dump_openapi.py`.
+
+CodeQL runs on every PR. Pre-commit hooks aren't installed by default -- wire them with `git config core.hooksPath .githooks` after the `.githooks` directory is in place.
 
 ## Status
 
-This is a planning package, not code. The build plan is the spec to implement against. Every major decision in it was reviewed section by section and locked.
+This is the working main branch through Phase 13 of the build plan. The feed serves real episodes end to end. Auth, retention, runtime settings, PWA install, reference-voice management, and the operator UI are all wired.
 
-## License
-
-Code (once written) is intended to be MIT. The Audicle name and logo are reserved; see `branding/README.md`. XTTS-v2 model weights are CPML (non-commercial); see the build plan's License Notes.
+What's not done: multi-host scale-out, multi-user accounts, and any monetization plumbing. None of those are on the roadmap.

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -3,17 +3,18 @@
 - /health/live: liveness probe, no dependency checks.
 - /health/ready: readiness probe, includes dependency status.
 - /health: alias for /health/ready (kept for backward compatibility).
-
-Later phases extend /health/ready with TTS wrapper, Firecrawl, LLM status.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import platform
+import subprocess
 import time
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, Request, Response, status
 
 from app.config import get_settings
@@ -31,41 +32,119 @@ def health_live() -> dict[str, Any]:
 
 @router.get("/health/ready")
 @router.get("/health")
-def health_ready(request: Request, response: Response) -> dict[str, Any]:
+async def health_ready(request: Request, response: Response) -> dict[str, Any]:
     settings = get_settings()
     checks: dict[str, str] = {}
 
     try:
-        conn = database.connect(database.db_path(settings.DATA_DIR))
-        try:
+        with database.connection(settings.DATA_DIR) as conn:
             conn.execute("SELECT 1").fetchone()
-            checks["db"] = "ok"
-        finally:
-            conn.close()
+        checks["db"] = "ok"
     except Exception as exc:
         logger.warning(
             "Readiness DB check failed",
             extra={"event": "health_db_error", "error": str(exc)},
             exc_info=True,
         )
-        # Generic ``"error"`` rather than the raw exception string so
-        # /health/ready (unauthenticated, conventionally polled by public
-        # load balancers) doesn't leak DATA_DIR paths or errno text. The
-        # full exception is in the WARN log above.
         checks["db"] = "error"
+
+    components: dict[str, Any] = {
+        "app": __version__,
+        "python": platform.python_version(),
+        "ffmpeg": _ffmpeg_version(),
+    }
+
+    # Fan probes out concurrently so one stuck upstream can't add its
+    # timeout budget to the others'. return_exceptions=True ensures one
+    # raising probe doesn't cancel the others and 500 the whole endpoint.
+    llm_url = (
+        settings.OPENAI_BASE_URL
+        if settings.LLM_PROVIDER == "openai-compatible"
+        else None
+    )
+    results = await asyncio.gather(
+        _probe_http(settings.TTS_URL, "/health", 2.0),
+        _probe_http(settings.FIRECRAWL_URL, "/health", 2.0),
+        _probe_http(llm_url, "/models", 2.0),
+        return_exceptions=True,
+    )
+    checks["tts"] = _coerce_result(results[0])
+    checks["firecrawl"] = _coerce_result(results[1])
+    checks["llm"] = _coerce_result(results[2])
 
     started_at = getattr(request.app.state, "started_at", time.monotonic())
     body: dict[str, Any] = {
-        "ok": all(value == "ok" for value in checks.values()),
+        "ok": all(v in {"ok", "skipped"} for v in checks.values()),
         "version": __version__,
         "uptime_seconds": int(time.monotonic() - started_at),
-        "components": {
-            "app": __version__,
-            "python": platform.python_version(),
-        },
+        "components": components,
         "checks": checks,
     }
 
     if not body["ok"]:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     return body
+
+
+def _coerce_result(value: Any) -> str:
+    if isinstance(value, BaseException):
+        return f"error_{type(value).__name__}"
+    return str(value)
+
+
+def _ffmpeg_version() -> str:
+    """First-line ffmpeg version banner. Successful lookups are cached
+    for the process lifetime via ``_ffmpeg_version_cached``; failures
+    are deliberately NOT cached so a late PATH fix becomes visible."""
+
+    cached = _ffmpeg_version_cached.get()
+    if cached is not None:
+        return cached
+    try:
+        out = subprocess.run(
+            ["ffmpeg", "-version"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+        if out.returncode != 0:
+            return "error"
+        first_line = out.stdout.split("\n", 1)[0]
+        parts = first_line.split()
+        version = parts[2] if len(parts) >= 3 else "unknown"
+        _ffmpeg_version_cached.set(version)
+        return version
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return "missing"
+
+
+class _OnceCache:
+    """Single-slot cache that only ever accepts a successful value;
+    failure sentinels are re-tried on every call."""
+
+    def __init__(self) -> None:
+        self._value: str | None = None
+
+    def get(self) -> str | None:
+        return self._value
+
+    def set(self, value: str) -> None:
+        self._value = value
+
+
+_ffmpeg_version_cached = _OnceCache()
+
+
+async def _probe_http(base: str | None, path: str, timeout_secs: float) -> str:
+    """``GET {base}{path}`` -> ``"ok"`` on 2xx, else a short reason."""
+
+    if not base:
+        return "skipped"
+    url = f"{base.rstrip('/')}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout_secs) as client:
+            r = await client.get(url)
+        return "ok" if r.is_success else f"http_{r.status_code}"
+    except httpx.HTTPError as exc:
+        return f"unreachable_{type(exc).__name__}"

--- a/backend/app/api/v1/reference.py
+++ b/backend/app/api/v1/reference.py
@@ -1,0 +1,262 @@
+"""``/api/v1/reference/*`` -- operator-side reference voice management.
+
+Three endpoints:
+
+- ``GET /api/v1/reference/preview`` returns the currently-installed
+  ``voice.wav`` (the clip the TTS wrapper conditions on).
+- ``POST /api/v1/reference/test`` accepts a candidate WAV + sample text,
+  calls the TTS wrapper using the candidate (without permanently
+  committing it), and returns the generated audio for audition.
+- ``POST /api/v1/reference/commit`` accepts a candidate WAV, validates,
+  atomically swaps it into ``backend/app/reference/voice.wav``, and
+  asks the TTS wrapper to ``/reload`` so the next ``/generate`` call
+  uses the new voice without a container restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import wave
+from pathlib import Path
+from typing import Annotated
+
+import httpx
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse, Response
+
+from app.api.deps import require_admin
+from app.config import Settings, get_settings
+from app.services.atomic_write import write_bytes_atomic
+
+logger = logging.getLogger("app.api.reference")
+router = APIRouter(prefix="/reference", tags=["reference"])
+
+# Voice clip spec per build-plan: mono, 24 kHz target (16-48 acceptable),
+# 6-15 s, ~150 kB-1.5 MB. The caps below are deliberate floors/ceilings
+# that catch obvious mis-uploads without rejecting borderline-good clips.
+_MAX_REFERENCE_BYTES = 5 * 1024 * 1024
+_MIN_DURATION_SECS = 3.0
+_MAX_DURATION_SECS = 60.0
+
+# Serialises /test against itself so two operators auditioning candidates
+# can't race on the shared reference path. /commit doesn't need the lock
+# (atomic rename) but takes it anyway to prevent /test seeing a half-
+# swapped voice.
+_reference_lock = asyncio.Lock()
+
+
+def _reference_path() -> Path:
+    """Where the wrapper picks the voice clip up. Matches the bind mount
+    in docker-compose."""
+
+    return Path(__file__).resolve().parent.parent.parent / "reference" / "voice.wav"
+
+
+def _validate_wav(data: bytes) -> tuple[int, float]:
+    """Return ``(sample_rate, duration_secs)`` if ``data`` is a readable
+    WAV; raise HTTPException(400) otherwise."""
+
+    if len(data) > _MAX_REFERENCE_BYTES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"voice clip must be <= {_MAX_REFERENCE_BYTES} bytes",
+        )
+    try:
+        with wave.open(io.BytesIO(data), "rb") as wav:
+            sample_rate = wav.getframerate()
+            frames = wav.getnframes()
+    except (wave.Error, EOFError) as exc:
+        raise HTTPException(
+            status_code=400, detail=f"could not read WAV: {exc}"
+        ) from exc
+    duration = frames / sample_rate if sample_rate else 0.0
+    if duration < _MIN_DURATION_SECS or duration > _MAX_DURATION_SECS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"voice clip duration {duration:.1f}s outside "
+                f"[{_MIN_DURATION_SECS}, {_MAX_DURATION_SECS}] window"
+            ),
+        )
+    return sample_rate, duration
+
+
+async def _read_upload_capped(voice: UploadFile) -> bytes:
+    """Stream the upload into a bytes object, aborting with 400 as soon
+    as it crosses the cap so a hostile payload can't fully buffer first."""
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await voice.read(64 * 1024)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > _MAX_REFERENCE_BYTES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"voice clip must be <= {_MAX_REFERENCE_BYTES} bytes",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@router.get("/preview", dependencies=[Depends(require_admin)])
+async def preview() -> FileResponse:
+    path = _reference_path()
+    if not path.is_file():
+        raise HTTPException(
+            status_code=404, detail="reference voice.wav not installed"
+        )
+    return FileResponse(path, media_type="audio/wav")
+
+
+@router.post("/test", dependencies=[Depends(require_admin)])
+async def test_candidate(
+    settings: Annotated[Settings, Depends(get_settings)],
+    voice: Annotated[UploadFile, File(description="candidate voice WAV")],
+    sample_text: Annotated[
+        str,
+        Form(
+            min_length=4,
+            max_length=400,
+            description="text to synthesize using the candidate clip",
+        ),
+    ] = "The quick brown fox jumps over the lazy dog.",
+) -> Response:
+    """Synthesize ``sample_text`` using ``voice`` without committing.
+
+    Staged through the live reference path so the wrapper picks it up
+    via /reload; on every exit path the committed clip is restored. If
+    no clip was previously committed, the candidate is removed on exit
+    so /test never silently turns into /commit.
+    """
+
+    candidate = await _read_upload_capped(voice)
+    _validate_wav(candidate)
+
+    reference = _reference_path()
+    reference.parent.mkdir(parents=True, exist_ok=True)
+
+    async with _reference_lock:
+        backup = reference.read_bytes() if reference.is_file() else None
+        try:
+            write_bytes_atomic(reference, candidate, prefix=".ref-test-")
+            async with httpx.AsyncClient(
+                timeout=settings.TTS_HTTP_TIMEOUT_SECONDS
+            ) as client:
+                try:
+                    await client.post(f"{settings.TTS_URL.rstrip('/')}/reload")
+                except httpx.HTTPError as exc:
+                    raise HTTPException(
+                        status_code=502,
+                        detail=f"tts wrapper /reload failed: {exc}",
+                    ) from exc
+                response = await client.post(
+                    f"{settings.TTS_URL.rstrip('/')}/generate",
+                    json={
+                        "text": sample_text,
+                        "episode_id": "reftest",
+                        "chunk_index": 0,
+                    },
+                )
+                if response.status_code != 200:
+                    raise HTTPException(
+                        status_code=502,
+                        detail=f"tts wrapper /generate returned {response.status_code}",
+                    )
+                wav_path = Path(response.json()["wav_path"]).resolve()
+                # Wrapper-supplied path is constrained to DATA_DIR so a
+                # compromised or misconfigured wrapper can't trick the
+                # backend into reading arbitrary files.
+                data_root = Path(settings.DATA_DIR).resolve()
+                if not wav_path.is_relative_to(data_root) or not wav_path.is_file():
+                    raise HTTPException(
+                        status_code=502,
+                        detail="tts wrapper returned an invalid wav path",
+                    )
+                body = wav_path.read_bytes()
+                # Restore (or remove if there was nothing committed) and
+                # reload BEFORE releasing the lock so the next /generate
+                # never sees the candidate.
+                _restore_or_clear(reference, backup)
+                await _reload_silently(client, settings)
+                return Response(content=body, media_type="audio/wav")
+        except Exception:
+            # Generate path raised after the candidate was staged: roll
+            # back disk state on the way out. Reload is best-effort.
+            _restore_or_clear(reference, backup)
+            async with httpx.AsyncClient(
+                timeout=settings.TTS_HTTP_TIMEOUT_SECONDS
+            ) as cleanup_client:
+                await _reload_silently(cleanup_client, settings)
+            raise
+
+
+@router.post("/commit", dependencies=[Depends(require_admin)])
+async def commit_candidate(
+    settings: Annotated[Settings, Depends(get_settings)],
+    voice: Annotated[UploadFile, File(description="new voice WAV to install")],
+) -> dict[str, str | int | bool]:
+    """Atomically replace ``backend/app/reference/voice.wav`` and ask the
+    TTS wrapper to ``/reload`` so the next ``/generate`` picks it up."""
+
+    candidate = await _read_upload_capped(voice)
+    sample_rate, duration_secs = _validate_wav(candidate)
+
+    reference = _reference_path()
+    reference.parent.mkdir(parents=True, exist_ok=True)
+
+    async with _reference_lock:
+        write_bytes_atomic(reference, candidate, prefix=".ref-")
+        async with httpx.AsyncClient(
+            timeout=settings.TTS_HTTP_TIMEOUT_SECONDS
+        ) as client:
+            try:
+                await client.post(f"{settings.TTS_URL.rstrip('/')}/reload")
+            except httpx.HTTPError as exc:
+                # Clip is committed on disk; the wrapper just didn't
+                # reload. Operator can re-trigger.
+                return {
+                    "committed": True,
+                    "tts_reload_warning": str(exc),
+                    "sample_rate": sample_rate,
+                    "duration_secs": round(duration_secs),
+                }
+    return {
+        "committed": True,
+        "sample_rate": sample_rate,
+        "duration_secs": round(duration_secs),
+    }
+
+
+def _restore_or_clear(reference: Path, backup: bytes | None) -> None:
+    """Either restore the prior reference clip or remove the staged
+    candidate when no prior clip existed."""
+
+    try:
+        if backup is not None:
+            write_bytes_atomic(reference, backup, prefix=".ref-restore-")
+        else:
+            reference.unlink(missing_ok=True)
+    except OSError:
+        logger.error(
+            "Reference rollback failed -- manual recovery required",
+            extra={"event": "reference_rollback_failed", "path": str(reference)},
+            exc_info=True,
+        )
+
+
+async def _reload_silently(client: httpx.AsyncClient, settings: Settings) -> None:
+    """Best-effort /reload call. Logs HTTP errors so an operator can see
+    that the wrapper may be out of sync with disk."""
+
+    try:
+        await client.post(f"{settings.TTS_URL.rstrip('/')}/reload")
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "TTS /reload after restore failed",
+            extra={"event": "tts_reload_failed", "error": str(exc)},
+        )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -10,6 +10,7 @@ from app.api.v1 import episodes as episodes_routes
 from app.api.v1 import jobs as jobs_routes
 from app.api.v1 import prompt as prompt_routes
 from app.api.v1 import purge as purge_routes
+from app.api.v1 import reference as reference_routes
 from app.api.v1 import settings as settings_routes
 from app.api.v1 import status as status_routes
 from app.api.v1 import submit as submit_routes
@@ -24,3 +25,4 @@ router.include_router(auth_routes.router)
 router.include_router(settings_routes.router)
 router.include_router(episodes_routes.router)
 router.include_router(jobs_routes.router)
+router.include_router(reference_routes.router)

--- a/backend/app/reference/README.md
+++ b/backend/app/reference/README.md
@@ -1,0 +1,53 @@
+# Reference Voice (`voice.wav`)
+
+The XTTS-v2 wrapper conditions on a single short voice sample to colour every
+synthesis call. Drop your clip at `backend/app/reference/voice.wav`; the
+container bind-mounts it read-only into the wrapper at
+`/app/reference/voice.wav`.
+
+## Spec
+
+| Property | Recommended | Hard limits (enforced by `/api/v1/reference/commit`) |
+|---|---|---|
+| Format | WAV (PCM, 16-bit) | WAV that Python's `wave` module can read |
+| Channels | mono | mono or stereo (XTTS mixes down internally) |
+| Sample rate | 24 kHz | 16-48 kHz |
+| Duration | 8-12 seconds | 3-60 seconds |
+| Loudness | -20 to -16 LUFS | n/a |
+| Content | clean speech, no background music, no silence padding | n/a |
+| Size | ~250 kB - 1 MB | <= 5 MB |
+
+## How to source one
+
+Three reasonable paths:
+
+1. **Record yourself**: phone voice memo in a quiet room, then trim with
+   `ffmpeg -i raw.m4a -ac 1 -ar 24000 -ss 3 -to 13 -acodec pcm_s16le voice.wav`.
+   Read a few sentences with neutral cadence; the wrapper picks up your
+   prosody more than your vocabulary.
+2. **Reuse a creative-commons voice** from the LibriVox / LJSpeech / VCTK
+   corpora. Verify the licence allows derivative work (LJSpeech and VCTK
+   are CC0 / CC BY 4.0).
+3. **Synthesize one** from a paid voice provider you have rights to.
+   Don't use a celebrity voice you don't own; the XTTS weights happily
+   reproduce it.
+
+## Licence note
+
+The XTTS-v2 model weights are governed by the Coqui Public Model Licence
+1.0.0 (CPML). It is non-commercial. Personal self-hosted use is fine; do
+not redistribute generated audio commercially without checking the licence
+text in the `tts-wrapper/` directory.
+
+## Verifying
+
+```bash
+ffprobe -hide_banner voice.wav
+# Expect: pcm_s16le, mono, 24000 Hz, ~10s
+```
+
+The admin UI's Settings page has a "reference voice" widget that previews
+the installed clip, lets you upload a candidate, auditions it against
+sample text via `POST /api/v1/reference/test`, and atomically swaps the
+live clip via `POST /api/v1/reference/commit` (which also triggers the
+wrapper's `/reload`).

--- a/backend/tests/test_api_reference.py
+++ b/backend/tests/test_api_reference.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import io
+import wave
+from pathlib import Path
+
+import httpx
+import pytest
+from app.core import database
+from app.main import create_app
+from fastapi.testclient import TestClient
+
+
+def _wav_bytes(*, duration_secs: float = 10.0, sample_rate: int = 24000) -> bytes:
+    """Synthesize a silent mono PCM-16 WAV of the given duration."""
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(b"\x00\x00" * int(sample_rate * duration_secs))
+    return buf.getvalue()
+
+
+def _client(env: Path) -> TestClient:
+    database.run_migrations(env)
+    return TestClient(create_app())
+
+
+def test_preview_returns_404_when_no_reference_installed(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.api.v1 import reference
+
+    monkeypatch.setattr(
+        reference,
+        "_reference_path",
+        lambda: env / "voice_does_not_exist.wav",
+    )
+    with _client(env) as client:
+        response = client.get("/api/v1/reference/preview")
+    assert response.status_code == 404
+
+
+def test_preview_serves_installed_clip(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.api.v1 import reference
+
+    path = env / "voice.wav"
+    path.write_bytes(_wav_bytes())
+    monkeypatch.setattr(reference, "_reference_path", lambda: path)
+    with _client(env) as client:
+        response = client.get("/api/v1/reference/preview")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert response.content.startswith(b"RIFF")
+
+
+def test_commit_atomically_swaps_voice_and_calls_reload(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The endpoint validates the candidate WAV, replaces voice.wav, and
+    POSTs /reload to the TTS wrapper."""
+
+    from app.api.v1 import reference
+
+    path = env / "voice.wav"
+    path.write_bytes(b"OLDFAKE")
+    monkeypatch.setattr(reference, "_reference_path", lambda: path)
+
+    reload_calls: list[str] = []
+
+    def _handler(request):
+        reload_calls.append(str(request.url))
+        return httpx.Response(200, json={"reloaded": True})
+
+    transport = httpx.MockTransport(_handler)
+    original = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+    new_clip = _wav_bytes(duration_secs=8.0)
+    with _client(env) as client:
+        response = client.post(
+            "/api/v1/reference/commit",
+            files={"voice": ("new.wav", new_clip, "audio/wav")},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    # JSON booleans round-trip as Python bools but the route returns the
+    # raw int from a literal; tolerate truthy.
+    assert body["committed"]
+    assert body["sample_rate"] == 24000
+    assert body["duration_secs"] == 8
+    assert path.read_bytes() == new_clip
+    assert any("/reload" in url for url in reload_calls)
+
+
+def test_commit_rejects_too_short_clip(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.api.v1 import reference
+
+    path = env / "voice.wav"
+    monkeypatch.setattr(reference, "_reference_path", lambda: path)
+
+    too_short = _wav_bytes(duration_secs=1.0)
+    with _client(env) as client:
+        response = client.post(
+            "/api/v1/reference/commit",
+            files={"voice": ("short.wav", too_short, "audio/wav")},
+        )
+    assert response.status_code == 400
+
+
+def test_commit_rejects_oversized_clip(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.api.v1 import reference
+
+    path = env / "voice.wav"
+    monkeypatch.setattr(reference, "_reference_path", lambda: path)
+
+    huge = b"\x00" * (6 * 1024 * 1024)
+    with _client(env) as client:
+        response = client.post(
+            "/api/v1/reference/commit",
+            files={"voice": ("huge.wav", huge, "audio/wav")},
+        )
+    assert response.status_code == 400
+
+
+def test_commit_rejects_non_wav_payload(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.api.v1 import reference
+
+    path = env / "voice.wav"
+    monkeypatch.setattr(reference, "_reference_path", lambda: path)
+
+    with _client(env) as client:
+        response = client.post(
+            "/api/v1/reference/commit",
+            files={"voice": ("nope.txt", b"not a wav file at all", "audio/wav")},
+        )
+    assert response.status_code == 400

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -21,7 +21,22 @@ def test_health_live(env: Path) -> None:
     assert body["version"]
 
 
-def test_health_ready_ok(env: Path) -> None:
+def _stub_probes(monkeypatch) -> None:
+    """Health aggregation hits real network for TTS/Firecrawl/LLM; in tests
+    the configured URLs are sinkholes. Stub the probe + ffmpeg banner so the
+    happy-path assertion isolates the DB check."""
+
+    from app.api import health as health_mod
+
+    async def _ok(*_a, **_kw):
+        return "ok"
+
+    monkeypatch.setattr(health_mod, "_probe_http", _ok)
+    monkeypatch.setattr(health_mod, "_ffmpeg_version", lambda: "stub")
+
+
+def test_health_ready_ok(env: Path, monkeypatch) -> None:
+    _stub_probes(monkeypatch)
     with _client(env) as client:
         response = client.get("/health/ready")
     assert response.status_code == 200
@@ -32,7 +47,8 @@ def test_health_ready_ok(env: Path) -> None:
     assert body["components"]["python"]
 
 
-def test_health_alias_returns_same_shape(env: Path) -> None:
+def test_health_alias_returns_same_shape(env: Path, monkeypatch) -> None:
+    _stub_probes(monkeypatch)
     with _client(env) as client:
         ready = client.get("/health/ready").json()
         alias = client.get("/health").json()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,7 +10,7 @@
 
 const CSRF_COOKIE = "audicle_csrf";
 
-function readCsrf(): string | null {
+export function readCsrf(): string | null {
   const prefix = `${CSRF_COOKIE}=`;
   for (const piece of document.cookie.split(";")) {
     const trimmed = piece.trim();

--- a/frontend/src/routes/Feed.tsx
+++ b/frontend/src/routes/Feed.tsx
@@ -1,6 +1,37 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api, Episode } from "../lib/api";
+
+/**
+ * Pull-to-refresh: track touchstart at the top of the document, and if
+ * the user drags down ~80 px before lifting, invalidate the episodes
+ * query so React Query refetches. Mobile-only by design; desktop users
+ * have the browser refresh button.
+ */
+function usePullToRefresh(onRefresh: () => void) {
+  const startY = useRef<number | null>(null);
+  useEffect(() => {
+    const onStart = (e: TouchEvent) => {
+      if (window.scrollY > 0) {
+        startY.current = null;
+        return;
+      }
+      startY.current = e.touches[0].clientY;
+    };
+    const onEnd = (e: TouchEvent) => {
+      if (startY.current === null) return;
+      const dy = e.changedTouches[0].clientY - startY.current;
+      startY.current = null;
+      if (dy > 80) onRefresh();
+    };
+    window.addEventListener("touchstart", onStart, { passive: true });
+    window.addEventListener("touchend", onEnd, { passive: true });
+    return () => {
+      window.removeEventListener("touchstart", onStart);
+      window.removeEventListener("touchend", onEnd);
+    };
+  }, [onRefresh]);
+}
 
 export default function Feed() {
   const [copied, setCopied] = useState(false);
@@ -10,6 +41,9 @@ export default function Feed() {
   const episodesQ = useQuery({
     queryKey: ["episodes"],
     queryFn: () => api<Episode[]>("/api/v1/episodes?per_page=50"),
+  });
+  usePullToRefresh(() => {
+    qc.invalidateQueries({ queryKey: ["episodes"] });
   });
 
   const deleteM = useMutation({

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,6 +1,41 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api, SettingsPayload } from "../lib/api";
+import { api, readCsrf, SettingsPayload } from "../lib/api";
+
+/**
+ * Five operator-facing groups per build-plan Phase 11, plus the prompt
+ * editor (which talks to /api/v1/prompt), the corrections table (which
+ * talks to /api/v1/corrections), and the reference voice widget
+ * (preview/test/commit against /api/v1/reference). System info is a
+ * read-only block.
+ */
+
+const GROUPS: Record<string, string[]> = {
+  Feed: [
+    "FEED_TITLE",
+    "FEED_DESCRIPTION",
+    "FEED_AUTHOR",
+    "FEED_EMAIL",
+    "FEED_LANGUAGE",
+    "FEED_CATEGORY",
+    "FEED_EXPLICIT",
+    "FEED_ARTWORK_URL",
+  ],
+  TTS: ["TTS_CHUNK_TARGET_WORDS", "TTS_CHUNK_MAX_WORDS", "TTS_CHUNK_SILENCE_MS"],
+  Cleanup: ["MIN_CLEANUP_CHARS", "MAX_PROMPT_LENGTH_BYTES"],
+  Retention: ["RETENTION_DAYS"],
+  RSS: ["RSS_CACHE_MAX_AGE_SECONDS"],
+};
+
+interface PromptBody {
+  prompt: string;
+}
+
+interface AuthStatus {
+  auth_enabled: boolean;
+  logged_in: boolean;
+  username: string | null;
+}
 
 export default function SettingsRoute() {
   const qc = useQueryClient();
@@ -8,18 +43,34 @@ export default function SettingsRoute() {
     queryKey: ["settings"],
     queryFn: () => api<SettingsPayload>("/api/v1/settings"),
   });
+  const promptQ = useQuery({
+    queryKey: ["prompt"],
+    queryFn: () => api<PromptBody>("/api/v1/prompt"),
+  });
+  const correctionsQ = useQuery({
+    queryKey: ["corrections"],
+    queryFn: () => api<Record<string, string>>("/api/v1/corrections"),
+  });
+  const authQ = useQuery({
+    queryKey: ["auth_status_settings"],
+    queryFn: () => api<AuthStatus>("/api/v1/auth/status"),
+  });
 
   const [draft, setDraft] = useState<Record<string, string>>({});
   const [savedMsg, setSavedMsg] = useState<string | null>(null);
+  const seeded = useRef(false);
 
+  // Seed the draft once on first arrival; subsequent refetches must not
+  // clobber unsaved field edits.
   useEffect(() => {
-    if (settingsQ.data) {
+    if (!seeded.current && settingsQ.data) {
       const next: Record<string, string> = {};
       for (const key of settingsQ.data.allowlist) {
         const v = settingsQ.data.values[key];
         next[key] = v === undefined || v === null ? "" : String(v);
       }
       setDraft(next);
+      seeded.current = true;
     }
   }, [settingsQ.data]);
 
@@ -40,9 +91,6 @@ export default function SettingsRoute() {
     const payload: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(draft)) {
       if (value === "") continue;
-      // Best-effort type coercion. Server does its own coercion via the
-      // Settings field annotation; this is just so booleans / numbers
-      // travel as the right JSON shape.
       if (value === "true") payload[key] = true;
       else if (value === "false") payload[key] = false;
       else if (!Number.isNaN(Number(value)) && value.trim() !== "")
@@ -52,39 +100,317 @@ export default function SettingsRoute() {
     putM.mutate(payload);
   };
 
+  if (settingsQ.isLoading) return <p className="text-mute text-sm">loading…</p>;
+
   return (
-    <div className="space-y-6">
-      {settingsQ.isLoading && <p className="text-mute text-sm">loading…</p>}
-      {settingsQ.data && (
-        <section className="space-y-4">
-          {settingsQ.data.allowlist.map((key) => (
-            <div key={key}>
-              <label className="label" htmlFor={key}>
-                {key}
-              </label>
-              <input
-                id={key}
-                className="field"
-                value={draft[key] ?? ""}
-                onChange={(e) =>
-                  setDraft((prev) => ({ ...prev, [key]: e.target.value }))
-                }
-              />
-            </div>
-          ))}
-          <div className="flex items-center gap-3">
-            <button className="btn-primary" disabled={putM.isPending} onClick={save}>
-              {putM.isPending ? "saving…" : "save"}
-            </button>
-            {savedMsg && (
-              <span className="font-mono text-xs text-accent">{savedMsg}</span>
-            )}
-          </div>
-          <p className="font-mono text-[10px] uppercase text-mute mt-4">
-            settings stored in runtime_settings table; apply on next read.
-          </p>
-        </section>
-      )}
+    <div className="space-y-8">
+      {Object.entries(GROUPS).map(([group, keys]) => {
+        const visible = keys.filter((k) => settingsQ.data?.allowlist.includes(k));
+        if (visible.length === 0) return null;
+        return (
+          <section key={group} className="space-y-3">
+            <h2 className="font-mono uppercase text-xs text-dim">{group}</h2>
+            {visible.map((key) => (
+              <div key={key}>
+                <label className="label" htmlFor={key}>
+                  {key}
+                </label>
+                <input
+                  id={key}
+                  className="field"
+                  value={draft[key] ?? ""}
+                  onChange={(e) =>
+                    setDraft((p) => ({ ...p, [key]: e.target.value }))
+                  }
+                />
+              </div>
+            ))}
+          </section>
+        );
+      })}
+
+      <div className="flex items-center gap-3 sticky bottom-2">
+        <button className="btn-primary" disabled={putM.isPending} onClick={save}>
+          {putM.isPending ? "saving…" : "save all"}
+        </button>
+        {savedMsg && (
+          <span className="font-mono text-xs text-accent">{savedMsg}</span>
+        )}
+      </div>
+
+      {promptQ.data !== undefined && <PromptEditor initial={promptQ.data.prompt} />}
+      {correctionsQ.data !== undefined && <CorrectionsTable initial={correctionsQ.data} />}
+      <ReferenceVoiceWidget />
+
+      <section className="space-y-2 border-t border-line pt-6">
+        <h2 className="font-mono uppercase text-xs text-dim">system info</h2>
+        <ReadOnlyRow label="auth_enabled" value={String(authQ.data?.auth_enabled ?? "loading")} />
+        <ReadOnlyRow label="logged_in" value={String(authQ.data?.logged_in ?? "loading")} />
+        <ReadOnlyRow
+          label="allowlist_keys"
+          value={String(settingsQ.data?.allowlist.length ?? 0)}
+        />
+      </section>
     </div>
+  );
+}
+
+function ReadOnlyRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between font-mono text-[11px]">
+      <span className="text-dim uppercase">{label}</span>
+      <span className="text-fg">{value}</span>
+    </div>
+  );
+}
+
+function PromptEditor({ initial }: { initial: string }) {
+  const qc = useQueryClient();
+  // Seed from the initial prop via lazy initializer so the editor is
+  // pre-populated on mount; subsequent refetches arrive as a new
+  // PromptEditor instance only when the parent unmounts/remounts (we
+  // gate at the parent on data !== undefined), so in-progress edits are
+  // never clobbered.
+  const [text, setText] = useState(initial);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const m = useMutation({
+    mutationFn: () =>
+      api("/api/v1/prompt", {
+        method: "PUT",
+        body: JSON.stringify({ prompt: text }),
+      }),
+    onSuccess: () => {
+      setMsg("saved");
+      setTimeout(() => setMsg(null), 2000);
+      qc.invalidateQueries({ queryKey: ["prompt"] });
+    },
+  });
+
+  return (
+    <section className="space-y-3 border-t border-line pt-6">
+      <h2 className="font-mono uppercase text-xs text-dim">cleanup prompt</h2>
+      <textarea
+        className="field min-h-[200px] font-mono text-xs"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <div className="flex items-center gap-3">
+        <button className="btn-primary" disabled={m.isPending} onClick={() => m.mutate()}>
+          {m.isPending ? "saving…" : "save prompt"}
+        </button>
+        {msg && <span className="font-mono text-xs text-accent">{msg}</span>}
+      </div>
+    </section>
+  );
+}
+
+interface Row {
+  id: number;
+  k: string;
+  v: string;
+}
+
+let _rowCounter = 0;
+const newRow = (k = "", v = ""): Row => ({ id: ++_rowCounter, k, v });
+
+function CorrectionsTable({ initial }: { initial: Record<string, string> }) {
+  const qc = useQueryClient();
+  // Lazy initializer: seeded from the initial prop. Parent only mounts
+  // this component once the query has data, so refetches arriving as
+  // new identical props won't reset rows.
+  const [rows, setRows] = useState<Row[]>(() =>
+    Object.entries(initial).map(([k, v]) => newRow(k, v))
+  );
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const m = useMutation({
+    mutationFn: () => {
+      const obj: Record<string, string> = {};
+      for (const row of rows) {
+        if (row.k.trim()) obj[row.k.trim()] = row.v;
+      }
+      return api("/api/v1/corrections", {
+        method: "PUT",
+        body: JSON.stringify(obj),
+      });
+    },
+    onSuccess: () => {
+      setMsg("saved");
+      setTimeout(() => setMsg(null), 2000);
+      qc.invalidateQueries({ queryKey: ["corrections"] });
+    },
+  });
+
+  return (
+    <section className="space-y-3 border-t border-line pt-6">
+      <h2 className="font-mono uppercase text-xs text-dim">pronunciation corrections</h2>
+      <p className="text-mute text-xs">
+        left column: source word; right column: the spelling the TTS should narrate.
+      </p>
+      <div className="space-y-2">
+        {rows.map((row) => (
+          <div key={row.id} className="flex gap-2">
+            <input
+              className="field flex-1"
+              placeholder="word"
+              value={row.k}
+              onChange={(e) =>
+                setRows((rs) =>
+                  rs.map((r) => (r.id === row.id ? { ...r, k: e.target.value } : r))
+                )
+              }
+            />
+            <input
+              className="field flex-1"
+              placeholder="replacement"
+              value={row.v}
+              onChange={(e) =>
+                setRows((rs) =>
+                  rs.map((r) => (r.id === row.id ? { ...r, v: e.target.value } : r))
+                )
+              }
+            />
+            <button
+              className="btn-ghost text-danger"
+              onClick={() => setRows((rs) => rs.filter((r) => r.id !== row.id))}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button
+          className="btn-ghost"
+          onClick={() => setRows((r) => [...r, newRow()])}
+        >
+          add row
+        </button>
+      </div>
+      <div className="flex items-center gap-3">
+        <button className="btn-primary" disabled={m.isPending} onClick={() => m.mutate()}>
+          {m.isPending ? "saving…" : "save corrections"}
+        </button>
+        {msg && <span className="font-mono text-xs text-accent">{msg}</span>}
+      </div>
+    </section>
+  );
+}
+
+function ReferenceVoiceWidget() {
+  const [candidate, setCandidate] = useState<File | null>(null);
+  const [sample, setSample] = useState("The quick brown fox jumps over the lazy dog.");
+  const [testAudioUrl, setTestAudioUrl] = useState<string | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const previewUrl = "/api/v1/reference/preview";
+
+  useEffect(() => {
+    return () => {
+      if (testAudioUrl) URL.revokeObjectURL(testAudioUrl);
+    };
+  }, [testAudioUrl]);
+
+  const postForm = async (path: string, fd: FormData): Promise<Response | null> => {
+    const headers: Record<string, string> = {};
+    const csrf = readCsrf();
+    if (csrf) headers["X-CSRF-Token"] = csrf;
+    try {
+      return await fetch(path, {
+        method: "POST",
+        body: fd,
+        credentials: "include",
+        headers,
+      });
+    } catch {
+      return null;
+    }
+  };
+
+  const test = async () => {
+    if (!candidate) return;
+    setMsg(null);
+    const fd = new FormData();
+    fd.append("voice", candidate);
+    fd.append("sample_text", sample);
+    const r = await postForm("/api/v1/reference/test", fd);
+    if (!r) {
+      setMsg("test failed (network error)");
+      return;
+    }
+    if (!r.ok) {
+      setMsg(`test failed (${r.status})`);
+      return;
+    }
+    const blob = await r.blob();
+    setTestAudioUrl(URL.createObjectURL(blob));
+  };
+
+  const commit = async () => {
+    if (!candidate) return;
+    if (!confirm("Replace the current reference voice?")) return;
+    setMsg(null);
+    const fd = new FormData();
+    fd.append("voice", candidate);
+    const r = await postForm("/api/v1/reference/commit", fd);
+    if (!r) {
+      setMsg("commit failed (network error)");
+      return;
+    }
+    setMsg(r.ok ? "committed; TTS reloaded" : `commit failed (${r.status})`);
+    if (r.ok) {
+      setCandidate(null);
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  };
+
+  return (
+    <section className="space-y-3 border-t border-line pt-6">
+      <h2 className="font-mono uppercase text-xs text-dim">reference voice</h2>
+      <audio controls src={previewUrl} className="w-full" />
+      <div>
+        <label className="label" htmlFor="ref-file">
+          upload candidate WAV (3-60s, &lt;= 5 MB)
+        </label>
+        <input
+          id="ref-file"
+          ref={fileRef}
+          type="file"
+          accept="audio/wav"
+          className="field"
+          onChange={(e) => {
+            setCandidate(e.target.files?.[0] ?? null);
+            setTestAudioUrl(null);
+            setMsg(null);
+          }}
+        />
+      </div>
+      <div>
+        <label className="label" htmlFor="ref-sample">
+          sample text (for test only)
+        </label>
+        <input
+          id="ref-sample"
+          className="field"
+          value={sample}
+          onChange={(e) => setSample(e.target.value)}
+        />
+      </div>
+      <div className="flex gap-2 items-center flex-wrap">
+        <button className="btn-ghost" disabled={!candidate} onClick={test}>
+          test
+        </button>
+        <button className="btn-primary" disabled={!candidate} onClick={commit}>
+          commit
+        </button>
+        {msg && <span className="font-mono text-xs text-accent">{msg}</span>}
+      </div>
+      {testAudioUrl && (
+        <div>
+          <p className="label">audition</p>
+          <audio controls src={testAudioUrl} className="w-full" />
+        </div>
+      )}
+    </section>
   );
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,990 @@
+openapi: 3.1.0
+info:
+  title: Audicle
+  version: 0.1.0
+paths:
+  /health/live:
+    get:
+      tags:
+      - health
+      summary: Health Live
+      operationId: health_live_health_live_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Health Live Health Live Get
+  /health:
+    get:
+      tags:
+      - health
+      summary: Health Ready
+      operationId: health_ready_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Health Ready Health Get
+  /health/ready:
+    get:
+      tags:
+      - health
+      summary: Health Ready
+      operationId: health_ready_health_ready_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Health Ready Health Ready Get
+  /api/v1/submit:
+    post:
+      tags:
+      - jobs
+      summary: Submit an article URL for processing
+      operationId: submit_api_v1_submit_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitRequest'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/status/{job_id}:
+    get:
+      tags:
+      - jobs
+      summary: Fetch job status
+      operationId: status_api_v1_status__job_id__get
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app__api__v1__status__StatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/prompt:
+    get:
+      tags:
+      - prompt
+      summary: Read the cleanup prompt
+      operationId: read_prompt_api_v1_prompt_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptBody'
+    put:
+      tags:
+      - prompt
+      summary: Replace the cleanup prompt
+      operationId: write_prompt_api_v1_prompt_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromptBody'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptBody'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/corrections:
+    get:
+      tags:
+      - corrections
+      summary: Read the pronunciation dictionary
+      operationId: read_corrections_api_v1_corrections_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+                title: Response Read Corrections Api V1 Corrections Get
+    put:
+      tags:
+      - corrections
+      summary: Replace the pronunciation dictionary
+      operationId: write_corrections_api_v1_corrections_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Body
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Write Corrections Api V1 Corrections Put
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/purge:
+    post:
+      tags:
+      - maintenance
+      summary: Post Purge
+      operationId: post_purge_api_v1_purge_post
+      parameters:
+      - name: confirm
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Must be true to acknowledge the destructive action.
+          default: false
+          title: Confirm
+        description: Must be true to acknowledge the destructive action.
+      - name: older_than_days
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100000
+          minimum: 0
+          description: Purge episodes older than N days. 0 wipes everything.
+          default: 0
+          title: Older Than Days
+        description: Purge episodes older than N days. 0 wipes everything.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurgeResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/auth/login:
+    post:
+      tags:
+      - auth
+      summary: Post Login
+      operationId: post_login_api_v1_auth_login_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/auth/logout:
+    post:
+      tags:
+      - auth
+      summary: Post Logout
+      operationId: post_logout_api_v1_auth_logout_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: boolean
+                type: object
+                title: Response Post Logout Api V1 Auth Logout Post
+  /api/v1/auth/status:
+    get:
+      tags:
+      - auth
+      summary: Get Status
+      operationId: get_status_api_v1_auth_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app__api__v1__auth__StatusResponse'
+  /api/v1/settings:
+    get:
+      tags:
+      - settings
+      summary: Get Settings Overrides
+      operationId: get_settings_overrides_api_v1_settings_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsResponse'
+    put:
+      tags:
+      - settings
+      summary: Put Settings Overrides
+      operationId: put_settings_overrides_api_v1_settings_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Payload
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/episodes:
+    get:
+      tags:
+      - episodes
+      summary: List Episodes
+      operationId: list_episodes_api_v1_episodes_get
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+          title: Page
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 50
+          title: Per Page
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EpisodeListItem'
+                title: Response List Episodes Api V1 Episodes Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/episodes/{episode_id}:
+    delete:
+      tags:
+      - episodes
+      summary: Delete Episode
+      operationId: delete_episode_api_v1_episodes__episode_id__delete
+      parameters:
+      - name: episode_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Episode Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteEpisodeResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/jobs:
+    get:
+      tags:
+      - jobs
+      summary: List Jobs
+      operationId: list_jobs_api_v1_jobs_get
+      parameters:
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - enum:
+            - queued
+            - processing
+            - done
+            - failed
+            type: string
+          - type: 'null'
+          title: Status
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+          title: Page
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 50
+          title: Per Page
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JobListItem'
+                title: Response List Jobs Api V1 Jobs Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/reference/preview:
+    get:
+      tags:
+      - reference
+      summary: Preview
+      operationId: preview_api_v1_reference_preview_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/v1/reference/test:
+    post:
+      tags:
+      - reference
+      summary: Test Candidate
+      description: 'Synthesize ``sample_text`` using ``voice`` without committing
+        it.
+
+
+        The candidate is staged under a tempfile that the TTS wrapper reads
+
+        via the same bind-mounted reference path; we restore the committed
+
+        clip on return so a failed test never replaces the live voice.'
+      operationId: test_candidate_api_v1_reference_test_post
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_test_candidate_api_v1_reference_test_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/reference/commit:
+    post:
+      tags:
+      - reference
+      summary: Commit Candidate
+      description: 'Atomically replace ``backend/app/reference/voice.wav`` and ask
+        the
+
+        TTS wrapper to ``/reload`` so the next ``/generate`` picks it up.'
+      operationId: commit_candidate_api_v1_reference_commit_post
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_commit_candidate_api_v1_reference_commit_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  anyOf:
+                  - type: string
+                  - type: integer
+                type: object
+                title: Response Commit Candidate Api V1 Reference Commit Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /rss/rss.xml:
+    get:
+      tags:
+      - rss
+      summary: Get Rss
+      operationId: get_rss_rss_rss_xml_get
+      parameters:
+      - name: if-modified-since
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: If-Modified-Since
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /media/{episode_id}.mp3:
+    get:
+      tags:
+      - media
+      summary: Get Mp3
+      operationId: get_mp3_media__episode_id__mp3_get
+      parameters:
+      - name: episode_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Episode Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /media/{episode_id}.jpg:
+    get:
+      tags:
+      - media
+      summary: Get Jpg
+      operationId: get_jpg_media__episode_id__jpg_get
+      parameters:
+      - name: episode_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Episode Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /media/{episode_id}.vtt:
+    get:
+      tags:
+      - media
+      summary: Get Vtt
+      operationId: get_vtt_media__episode_id__vtt_get
+      parameters:
+      - name: episode_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Episode Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    Body_commit_candidate_api_v1_reference_commit_post:
+      properties:
+        voice:
+          type: string
+          contentMediaType: application/octet-stream
+          title: Voice
+          description: new voice WAV to install
+      type: object
+      required:
+      - voice
+      title: Body_commit_candidate_api_v1_reference_commit_post
+    Body_test_candidate_api_v1_reference_test_post:
+      properties:
+        voice:
+          type: string
+          contentMediaType: application/octet-stream
+          title: Voice
+          description: candidate voice WAV
+        sample_text:
+          type: string
+          maxLength: 400
+          minLength: 4
+          title: Sample Text
+          description: text to synthesize using the candidate clip
+          default: The quick brown fox jumps over the lazy dog.
+      type: object
+      required:
+      - voice
+      title: Body_test_candidate_api_v1_reference_test_post
+    DeleteEpisodeResponse:
+      properties:
+        id:
+          type: string
+          title: Id
+        files_removed:
+          type: integer
+          minimum: 0.0
+          title: Files Removed
+      additionalProperties: false
+      type: object
+      required:
+      - id
+      - files_removed
+      title: DeleteEpisodeResponse
+    EpisodeListItem:
+      properties:
+        id:
+          type: string
+          title: Id
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        author:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Author
+        original_url:
+          type: string
+          title: Original Url
+        audio_path:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Audio Path
+        artwork_path:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Artwork Path
+        duration_secs:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Duration Secs
+        pub_date:
+          type: string
+          title: Pub Date
+        updated_at:
+          type: string
+          title: Updated At
+      additionalProperties: false
+      type: object
+      required:
+      - id
+      - title
+      - author
+      - original_url
+      - audio_path
+      - artwork_path
+      - duration_secs
+      - pub_date
+      - updated_at
+      title: EpisodeListItem
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    JobListItem:
+      properties:
+        id:
+          type: string
+          title: Id
+        url:
+          type: string
+          title: Url
+        episode_id:
+          type: string
+          title: Episode Id
+        status:
+          type: string
+          title: Status
+        stage:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Stage
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+        created_at:
+          type: string
+          title: Created At
+        updated_at:
+          type: string
+          title: Updated At
+      additionalProperties: false
+      type: object
+      required:
+      - id
+      - url
+      - episode_id
+      - status
+      - stage
+      - error
+      - created_at
+      - updated_at
+      title: JobListItem
+    LoginRequest:
+      properties:
+        username:
+          type: string
+          maxLength: 200
+          minLength: 1
+          title: Username
+        password:
+          type: string
+          maxLength: 200
+          minLength: 1
+          title: Password
+      additionalProperties: false
+      type: object
+      required:
+      - username
+      - password
+      title: LoginRequest
+    LoginResponse:
+      properties:
+        logged_in:
+          type: boolean
+          title: Logged In
+        username:
+          type: string
+          title: Username
+        csrf_token:
+          type: string
+          title: Csrf Token
+      additionalProperties: false
+      type: object
+      required:
+      - logged_in
+      - username
+      - csrf_token
+      title: LoginResponse
+    PromptBody:
+      properties:
+        prompt:
+          type: string
+          minLength: 1
+          title: Prompt
+          description: Full cleanup prompt as a single string. Must contain at least
+            one non-whitespace character.
+      additionalProperties: false
+      type: object
+      required:
+      - prompt
+      title: PromptBody
+    PurgeResponse:
+      properties:
+        older_than_days:
+          type: integer
+          title: Older Than Days
+          description: Cutoff age in days
+        rows_deleted:
+          type: integer
+          title: Rows Deleted
+          description: Episode rows removed from the DB
+        files_removed:
+          type: integer
+          title: Files Removed
+          description: MP3/JPG/VTT files removed from disk
+        episode_ids:
+          items:
+            type: string
+          type: array
+          title: Episode Ids
+          description: IDs of removed episodes
+      additionalProperties: false
+      type: object
+      required:
+      - older_than_days
+      - rows_deleted
+      - files_removed
+      - episode_ids
+      title: PurgeResponse
+    SettingsResponse:
+      properties:
+        allowlist:
+          items:
+            type: string
+          type: array
+          title: Allowlist
+        values:
+          additionalProperties: true
+          type: object
+          title: Values
+      additionalProperties: false
+      type: object
+      required:
+      - allowlist
+      - values
+      title: SettingsResponse
+    SubmitRequest:
+      properties:
+        url:
+          type: string
+          maxLength: 2048
+          minLength: 1
+          title: Url
+          description: HTTP/HTTPS URL of the article to ingest.
+        reprocess:
+          type: boolean
+          title: Reprocess
+          description: When true and the URL already has an episode/job, wipe the
+            prior state and start fresh. Default is to return 409.
+          default: false
+      additionalProperties: false
+      type: object
+      required:
+      - url
+      title: SubmitRequest
+    SubmitResponse:
+      properties:
+        job_id:
+          type: string
+          title: Job Id
+        episode_id:
+          type: string
+          title: Episode Id
+        status:
+          type: string
+          title: Status
+        replaced_previous:
+          type: boolean
+          title: Replaced Previous
+          description: True if reprocess=true and a prior episode/job was deleted.
+          default: false
+      type: object
+      required:
+      - job_id
+      - episode_id
+      - status
+      title: SubmitResponse
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+        input:
+          title: Input
+        ctx:
+          type: object
+          title: Context
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+    app__api__v1__auth__StatusResponse:
+      properties:
+        auth_enabled:
+          type: boolean
+          title: Auth Enabled
+        logged_in:
+          type: boolean
+          title: Logged In
+        username:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Username
+        csrf_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Csrf Token
+      additionalProperties: false
+      type: object
+      required:
+      - auth_enabled
+      - logged_in
+      title: StatusResponse
+    app__api__v1__status__StatusResponse:
+      properties:
+        job_id:
+          type: string
+          title: Job Id
+        episode_id:
+          type: string
+          title: Episode Id
+        url:
+          type: string
+          title: Url
+        status:
+          type: string
+          title: Status
+        stage:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Stage
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+        created_at:
+          type: string
+          title: Created At
+        updated_at:
+          type: string
+          title: Updated At
+      type: object
+      required:
+      - job_id
+      - episode_id
+      - url
+      - status
+      - stage
+      - error
+      - created_at
+      - updated_at
+      title: StatusResponse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "itsdangerous>=2.2",
     "slowapi>=0.1.9",
     "pyyaml>=6.0.3",
+    "python-multipart>=0.0.29",
 ]
 
 [tool.uv.sources]

--- a/scripts/dump_openapi.py
+++ b/scripts/dump_openapi.py
@@ -7,14 +7,14 @@ Usage:
 from __future__ import annotations
 
 import json
-import sys
-from pathlib import Path
-
-import yaml
 
 # A few env vars are required by Settings; supply minimal placeholders so the
 # script can run outside a deployed environment.
 import os
+import sys
+from pathlib import Path
+
+import yaml
 
 os.environ.setdefault("BASE_URL", "https://example.test")
 os.environ.setdefault("UI_BASE_URL", "https://example.test")

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "slowapi" },
     { name = "soundfile" },
@@ -81,6 +82,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.4" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "python-multipart", specifier = ">=0.0.29" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "soundfile", specifier = ">=0.12" },
@@ -838,6 +840,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Closes 5 missing + 7 partial deliverables surfaced by the plan-completion audit. Ships Phase 11 (Web UI), reference voice management API + UI, `/health/ready` aggregation, `openapi.yaml`, and the reference voice docs.
- Folds in the full `/simplify` and `/code-review` fix lists: CSRF token truncation, React refetch-clobber, stale-key reorder bugs, wrapper-path SSRF, `except BaseException` + cancellation hazard, sentinel-cached ffmpeg `error` state, and several smaller correctness gaps.
- 332 backend tests pass. Ruff clean. Frontend `tsc --noEmit` clean.

## Test plan

- [x] `uv run pytest` -> 332 passed
- [x] `uv run ruff check backend scripts` -> All checks passed
- [x] `npx tsc --noEmit` (frontend) -> clean
- [ ] Smoke: bring up docker-compose, upload a candidate voice, audition, commit
- [ ] Smoke: hit `/health/ready` against a live wrapper, confirm component aggregation