### PR TITLE
Sync uv.lock to 0.28.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "audicle"
-version = "0.28.0"
+version = "0.28.1"
 source = { virtual = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## Summary

The 0.28.1 release bumped `VERSION`/`pyproject.toml` but the 0.28.1 commit missed
`uv.lock`, so the lock's `audicle` entry still read `0.28.0`. `uv lock` brings it in
line. Lock-metadata only -- one line, no dependency or code change.