### PR TITLE
Accept new unfixable base-image CVEs and bump pypdf for the 0.48.3 gate

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -59,3 +59,10 @@ CVE-2026-54369
 # Audicle uses soundfile (Python binding) for read/write only, no untrusted files.
 # Present in app and tts images; included here so the app scan (shared-only) passes.
 CVE-2026-37555
+
+# perl Storable (perl-base in app/render; libperl5.40, perl, perl-base,
+# perl-modules-5.40 in tts) (CRITICAL x1, "affected"): signed integer overflow
+# in Storable before 3.41 (CVE-2026-57433). Perl rides in the Debian base;
+# no application code invokes perl or deserializes Storable data. No Debian
+# fix released. Added 0.48.3. Remove when trixie ships a patched perl.
+CVE-2026-57433

--- a/.trivyignore.render
+++ b/.trivyignore.render
@@ -55,3 +55,10 @@ CVE-2026-34980
 # reachable on the internal Docker network. Added 0.48.2. Remove when Debian
 # trixie ships a patched libxml2.
 CVE-2026-6653
+
+# libtiff6 (HIGH x1, "will_not_fix"): DoS via large SamplesPerPixel tag
+# (CVE-2026-36849). TIFF support rides in via browser image deps; the render
+# sidecar only screenshots pages on the internal Docker network and never
+# processes operator-supplied TIFFs. Debian marks it will_not_fix for trixie.
+# Added 0.48.3. Remove if a patch ships.
+CVE-2026-36849

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ work lives under `[Unreleased]`.
 - The remaining tts-wrapper alerts (transformers, gradio, torch) are pinned
   by chatterbox-tts 0.1.7 and unreachable in the wrapper; they are dismissed
   on GitHub with the rationale recorded in tts-wrapper/pyproject.toml.
+- Bumped pypdf 6.13.3 to 6.14.2 after the release CVE gate flagged
+  CVE-2026-59935 and CVE-2026-59936 in the app image.
+- Accepted two new unfixable Debian base-image CVEs at the gate, with
+  rationale in the ignore files: CVE-2026-57433 (perl Storable, all three
+  images, no fix released) and CVE-2026-36849 (libtiff6 in the render
+  image, marked will_not_fix).
 
 ### Fixed
 

--- a/uv.lock
+++ b/uv.lock
@@ -1046,11 +1046,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.3"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The 0.48.3 release CVE gate flagged three new findings after fresh --pull rebuilds:

- pypdf CVE-2026-59935 / CVE-2026-59936 in the app image: fixable, bumped pypdf 6.13.3 -> 6.14.2 in uv.lock. File-extraction tests pass.
- CVE-2026-57433 (perl Storable signed integer overflow, CRITICAL, no Debian fix, hits all three images via the base): accepted in the shared .trivyignore with rationale; no application code invokes perl or deserializes Storable data.
- CVE-2026-36849 (libtiff6 DoS, HIGH, Debian will_not_fix, render image only): accepted in .trivyignore.render with rationale; the sidecar never processes operator-supplied TIFFs and is internal-only.

Gate now reports all three 0.48.3 images CLEAN.

## Test plan

- [x] scripts/trivy_gate.sh 0.48.3: all images CLEAN
- [x] backend file-extraction tests pass with pypdf 6.14.2
- [ ] Push images + deploy (release step)