### PR TITLE
Bump react-router-dom to 7.18.1

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -37,7 +37,14 @@ jobs:
           #     the model. None of the vulnerable paths exist in the wrapper: no form/multipart
           #     endpoints (JSON + GET only), no StaticFiles, no HTTPEndpoint classes, runs on
           #     Linux. Dismissed in the Dependabot tab with the same reasoning.
-          allow-ghsas: GHSA-98h9-4798-4q5v, GHSA-7wx4-6vff-v64p, GHSA-82w8-qh3p-5jfq, GHSA-wqp7-x3pw-xc5r, GHSA-jp82-jpqv-5vv3, GHSA-x746-7m8f-x49c
+          #   * GHSA-qwww-vcr4-c8h2 -- react-router RSC-mode CSRF bypass, vulnerable
+          #     >=7.12.0 <8.3.0. There is no fixed release: 7.18.1 is the latest published
+          #     version and no 8.x exists, so the only "fix" npm offers is a downgrade to
+          #     7.11.0, which reinstates the open-redirect/XSS advisories that 7.18.1 clears.
+          #     The vulnerable path is RSC / framework mode with server actions; the frontend
+          #     is a client-only SPA (BrowserRouter + Routes/Route/NavLink/Navigate) with no
+          #     RSC, no SSR, and no server actions. Revisit when 8.3.0 ships.
+          allow-ghsas: GHSA-98h9-4798-4q5v, GHSA-7wx4-6vff-v64p, GHSA-82w8-qh3p-5jfq, GHSA-wqp7-x3pw-xc5r, GHSA-jp82-jpqv-5vv3, GHSA-x746-7m8f-x49c, GHSA-qwww-vcr4-c8h2
           # The MIT/BSD/Apache/PSF set covers what we already use. LGPL-2.1/3.0 and
           # ZPL-2.1 were added deliberately: the gruut phonemizer (used for IPA
           # derivation) pulls num2words (LGPL) and pytz (MIT AND ZPL-2.1). LGPL/ZPL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Security
+
+- Bumped react-router-dom 6.30.4 to 7.18.1, clearing the open-redirect and
+  XSS advisories Dependabot flagged against the 6.x line. Dependabot's own
+  proposal (PR #105) targeted 7.0.0, which carries six high-severity
+  advisories of its own; 7.18.1 is the first release that clears them.
+  The frontend only uses BrowserRouter, Routes, Route, NavLink, Navigate,
+  and useNavigate, all unchanged in v7 declarative mode, so the upgrade
+  needed no code changes. Verified by building and driving the app: routes
+  render and client-side navigation works.
+- Accepted GHSA-qwww-vcr4-c8h2 (react-router RSC-mode CSRF bypass) in the
+  dependency-review allowlist. It has no fixed release yet, and the
+  vulnerable path is RSC/framework mode with server actions, which this
+  client-only SPA does not use.
+
 ## [0.48.3] - 2026-07-25
 
 ### Security

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@tanstack/react-query": "^5.62.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.4"
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -1769,15 +1769,6 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -3120,6 +3111,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -5480,35 +5484,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -5865,6 +5875,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "@tanstack/react-query": "^5.62.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.4"
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",


### PR DESCRIPTION
Supersedes #105.

## Why not #105

Dependabot proposed react-router-dom 7.0.0. That version carries six high-severity advisories of its own (XSS, SSR XSS in ScrollRestoration, XSS via open redirects, pre-render data spoofing, turbo-stream RCE, manifest DoS), so its dependency-review check fails and it would leave the app worse off than the current 6.30.4. 7.18.1 is the first release that clears both the 6.x advisories and those.

## Migration risk

None in practice. The frontend imports only `BrowserRouter`, `Routes`, `Route`, `NavLink`, `Navigate`, and `useNavigate` (three files), all unchanged in v7 declarative mode, and React 18.3.1 satisfies v7's `react >=18` peer requirement. No source changes were needed.

## One accepted advisory

`GHSA-qwww-vcr4-c8h2` (RSC-mode CSRF bypass) applies to >=7.12.0 <8.3.0. There is no fixed release: 7.18.1 is the latest published version, no 8.x exists, and npm's only suggested fix is a downgrade to 7.11.0 that reinstates the open-redirect advisories. The vulnerable path is RSC / framework mode with server actions; this is a client-only SPA with no RSC, no SSR, and no server actions. Added to the dependency-review allowlist with that rationale, alongside the existing chatterbox-pinned entries.

## Test plan

- [x] `npm run build` (tsc -b + vite build) passes
- [x] App driven in a browser: home and settings routes render, client-side nav and NavLink active state work, no router errors in console
- [x] `npm audit`: react-router open-redirect/XSS advisories cleared
- [ ] Ships in the next release build