### PR TITLE
Fix CPU deployment steps to build the wrapper image locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ work lives under `[Unreleased]`.
 
 ## [Unreleased]
 
+### Fixed
+
+- The README's CPU deployment steps told operators to pin
+  `ttlequals0/audicle-tts:<version>-cpu`. No such tag has been published
+  since 0.6.0, so anyone following that on a current version would find
+  nothing to pull. The steps now build the image from
+  `tts-wrapper/Dockerfile.cpu`, matching what tts-wrapper/README.md says.
+
 ### Security
 
 - Bumped react-router-dom 6.30.4 to 7.18.1, clearing the open-redirect and

--- a/README.md
+++ b/README.md
@@ -106,10 +106,15 @@ The container runs as a non-root user (uid 1000). If you bind-mount host directo
 chown -R 1000:1000 ./data ./backend/app/prompts ./backend/app/corrections ./backend/app/reference
 ```
 
-No CUDA GPU? `TTS_DEVICE=cpu` alone is not enough: the stock compose file pins the CUDA image and reserves an NVIDIA device. Three changes in `docker-compose.yml` get you a CPU deployment:
+No CUDA GPU? `TTS_DEVICE=cpu` alone is not enough: the stock compose file pins the CUDA image and reserves an NVIDIA device. Three steps get you a CPU deployment:
 
-1. Point the `tts-wrapper` service at the CPU image tag (`ttlequals0/audicle-tts:<version>-cpu`).
-2. Remove the `deploy.resources` GPU reservation from that service.
+1. Build the CPU wrapper image yourself. No current `-cpu` tag is published, so build it from the CPU Dockerfile:
+
+   ```bash
+   docker build -t audicle-tts:cpu -f tts-wrapper/Dockerfile.cpu tts-wrapper/
+   ```
+
+2. Point the `tts-wrapper` service at that image and remove the `deploy.resources` GPU reservation from it.
 3. Set `TTS_DEVICE=cpu` in `.env`.
 
 Then bring the stack up as usual:


### PR DESCRIPTION
The CPU deployment steps added in 0.48.3 told operators to pin `ttlequals0/audicle-tts:<version>-cpu`. That tag does not exist for any current version: the only published `-cpu` tags on Docker Hub are 0.2.0 through 0.6.0, so an operator following those steps on 0.48.3 has nothing to pull.

The steps now build the image from `tts-wrapper/Dockerfile.cpu`, which is what `tts-wrapper/README.md` already documents.

## Test plan

- [x] Verified against Docker Hub that no `-cpu` tag exists past 0.6.0
- [x] Confirmed `tts-wrapper/Dockerfile.cpu` exists and the build command matches the wrapper README